### PR TITLE
don't draw unlock-indicator if already on screen

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -291,36 +291,33 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
     }
 
     if (xr_screens > 0) {
-        /* This indicates if we have to draw the indicator to our current screen*/
-        bool draw_indicator = true;
 
         /* This keeps track of the screens drawn to */
         bool drawn_to[xr_screens];
-        for (int init = 0; init < xr_screens; init++) {
-            drawn_to[init] = false;
-        }
+        memset(drawn_to, false, sizeof(bool)*xr_screens);
 
         /* Composite the unlock indicator in the middle of each screen. */
         for (int screen = 0; screen < xr_screens; screen++) {
-            draw_indicator = true;
+            bool draw_indicator = true;
 
             int x = (xr_resolutions[screen].x + ((xr_resolutions[screen].width / 2) - (button_diameter_physical / 2)));
             int y = (xr_resolutions[screen].y + ((xr_resolutions[screen].height / 2) - (button_diameter_physical / 2)));
 
             for (int other = 0; other < screen; other++) {
-                if (drawn_to[other] == true) {
+                if (drawn_to[other]) {
                     if ((x > xr_resolutions[other].x) && (x < (xr_resolutions[other].x + xr_resolutions[other].width)) && ( y > xr_resolutions[other].y) && (y < (xr_resolutions[other].y + xr_resolutions[other].height))){
                         draw_indicator = false;
                     }
                 }
             }
 
-            if (draw_indicator == true) {
-                drawn_to[screen] = true;
-                cairo_set_source_surface(xcb_ctx, output, x, y);
-                cairo_rectangle(xcb_ctx, x, y, button_diameter_physical, button_diameter_physical);
-                cairo_fill(xcb_ctx);
-            }
+            if (!draw_indicator)
+                continue;
+
+            drawn_to[screen] = true;
+            cairo_set_source_surface(xcb_ctx, output, x, y);
+            cairo_rectangle(xcb_ctx, x, y, button_diameter_physical, button_diameter_physical);
+            cairo_fill(xcb_ctx);
         }
     } else {
         /* We have no information about the screen sizes/positions, so we just

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -272,13 +272,36 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
     }
 
     if (xr_screens > 0) {
+        /* This indicates if we have to draw the indicator to our current screen*/
+        bool draw_indicator = true;
+
+        /* This keeps track of the screens drawn to */
+        bool drawn_to[xr_screens];
+        for (int init = 0; init < xr_screens; init++) {
+            drawn_to[init] = false;
+        }
+
         /* Composite the unlock indicator in the middle of each screen. */
         for (int screen = 0; screen < xr_screens; screen++) {
+            draw_indicator = true;
+
             int x = (xr_resolutions[screen].x + ((xr_resolutions[screen].width / 2) - (button_diameter_physical / 2)));
             int y = (xr_resolutions[screen].y + ((xr_resolutions[screen].height / 2) - (button_diameter_physical / 2)));
-            cairo_set_source_surface(xcb_ctx, output, x, y);
-            cairo_rectangle(xcb_ctx, x, y, button_diameter_physical, button_diameter_physical);
-            cairo_fill(xcb_ctx);
+
+            for (int other = 0; other < screen; other++) {
+                if (drawn_to[other] == true) {
+                    if ((x > xr_resolutions[other].x) && (x < (xr_resolutions[other].x + xr_resolutions[other].width)) && ( y > xr_resolutions[other].y) && (y < (xr_resolutions[other].y + xr_resolutions[other].height))){
+                        draw_indicator = false;
+                    }
+                }
+            }
+
+            if (draw_indicator == true) {
+                drawn_to[screen] = true;
+                cairo_set_source_surface(xcb_ctx, output, x, y);
+                cairo_rectangle(xcb_ctx, x, y, button_diameter_physical, button_diameter_physical);
+                cairo_fill(xcb_ctx);
+            }
         }
     } else {
         /* We have no information about the screen sizes/positions, so we just

--- a/xinerama.c
+++ b/xinerama.c
@@ -65,7 +65,7 @@ void xinerama_query_screens(void) {
         return;
     }
     screen_info = xcb_xinerama_query_screens_screen_info(reply);
-    int screens = xcb_xinerama_query_screens_screen_info_length(reply);
+    int screens = 2;
 
     Rect *resolutions = malloc(screens * sizeof(Rect));
     /* No memory? Just keep on using the old information. */
@@ -76,15 +76,27 @@ void xinerama_query_screens(void) {
     xr_resolutions = resolutions;
     xr_screens = screens;
 
-    for (int screen = 0; screen < xr_screens; screen++) {
-        xr_resolutions[screen].x = screen_info[screen].x_org;
-        xr_resolutions[screen].y = screen_info[screen].y_org;
-        xr_resolutions[screen].width = screen_info[screen].width;
-        xr_resolutions[screen].height = screen_info[screen].height;
-        DEBUG("found Xinerama screen: %d x %d at %d x %d\n",
-              screen_info[screen].width, screen_info[screen].height,
-              screen_info[screen].x_org, screen_info[screen].y_org);
-    }
+//    for (int screen = 0; screen < xr_screens; screen++) {
+//        xr_resolutions[screen].x = screen_info[screen].x_org;
+//        xr_resolutions[screen].y = screen_info[screen].y_org;
+//        xr_resolutions[screen].width = screen_info[screen].width;
+//        xr_resolutions[screen].height = screen_info[screen].height;
+//        DEBUG("found Xinerama screen: %d x %d at %d x %d\n",
+//              screen_info[screen].width, screen_info[screen].height,
+//              screen_info[screen].x_org, screen_info[screen].y_org);
+//    }
+    xr_resolutions[0].x = 0;
+    xr_resolutions[0].y = 0;
+    xr_resolutions[0].width = 1024;
+    xr_resolutions[0].height = 768;
+    xr_resolutions[1].x = 200;
+    xr_resolutions[1].y = 0;
+    xr_resolutions[1].width = 1600;
+    xr_resolutions[1].height = 1024;
+//    xr_resolutions[2].x = 0;
+//    xr_resolutions[2].y = 0;
+//    xr_resolutions[2].width = 2880;
+//    xr_resolutions[2].height = 1800;
 
     free(reply);
 }


### PR DESCRIPTION
If we have multiple mirrored output, the unlock indicator will be drawn to both screens, and the second screen wil lshow the unlock indicator of the first, which looks bad if they don't show up at the same position. This patch tries to fix it by checking if the unlock-indicator will be visible on othe screens which already have one drawn to them.

Since i3lock has no test suite, I only tried some values for screen resolution and position, and it seems to work…