### PR TITLE
getting current user with whoami like function rather than from env variable

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -8,6 +8,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <pwd.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdbool.h>
@@ -658,8 +659,18 @@ static void raise_loop(xcb_window_t window) {
     }
 }
 
+char* whoami(void) {
+    uid_t uid = geteuid();
+    struct passwd *pw = getpwuid(uid);
+    if (pw) {
+        return pw->pw_name;
+     } else {
+        errx(EXIT_FAILURE, "Username not known!\n");
+     }
+}
+
 int main(int argc, char *argv[]) {
-    char *username;
+    char *username = whoami();
     char *image_path = NULL;
     int ret;
     struct pam_conv conv = {conv_callback, NULL};
@@ -683,9 +694,6 @@ int main(int argc, char *argv[]) {
         {"show-failed-attempts", no_argument, NULL, 'f'},
         {NULL, no_argument, NULL, 0}
     };
-
-    if ((username = getenv("USER")) == NULL)
-        errx(EXIT_FAILURE, "USER environment variable not set, please set it.\n");
 
     char *optstring = "hvnbdc:p:ui:teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {

--- a/i3lock.c
+++ b/i3lock.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pwd.h>
+#include <sys/types.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdbool.h>
@@ -659,18 +660,8 @@ static void raise_loop(xcb_window_t window) {
     }
 }
 
-char* whoami(void) {
-    uid_t uid = geteuid();
-    struct passwd *pw = getpwuid(uid);
-    if (pw) {
-        return pw->pw_name;
-     } else {
-        errx(EXIT_FAILURE, "Username not known!\n");
-     }
-}
-
 int main(int argc, char *argv[]) {
-    char *username = whoami();
+    char *username = getpwuid(getuid())->pw_name;
     char *image_path = NULL;
     int ret;
     struct pam_conv conv = {conv_callback, NULL};
@@ -694,6 +685,9 @@ int main(int argc, char *argv[]) {
         {"show-failed-attempts", no_argument, NULL, 'f'},
         {NULL, no_argument, NULL, 0}
     };
+
+    if (username == NULL)
+        err(EXIT_FAILURE, "getpwuid() failed");
 
     char *optstring = "hvnbdc:p:ui:teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {

--- a/i3lock.c
+++ b/i3lock.c
@@ -661,7 +661,7 @@ static void raise_loop(xcb_window_t window) {
 }
 
 int main(int argc, char *argv[]) {
-    struct passwd *pw = getpwuid(getuid());
+    struct passwd *pw;
     char *username;
     char *image_path = NULL;
     int ret;
@@ -687,7 +687,7 @@ int main(int argc, char *argv[]) {
         {NULL, no_argument, NULL, 0}
     };
 
-    if (pw == NULL)
+    if ((pw = getpwuid(getuid())) == NULL)
         err(EXIT_FAILURE, "getpwuid() failed");
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");

--- a/i3lock.c
+++ b/i3lock.c
@@ -661,7 +661,8 @@ static void raise_loop(xcb_window_t window) {
 }
 
 int main(int argc, char *argv[]) {
-    char *username = getpwuid(getuid())->pw_name;
+    struct passwd *pw = getpwuid(getuid());
+    char *username;
     char *image_path = NULL;
     int ret;
     struct pam_conv conv = {conv_callback, NULL};
@@ -686,8 +687,10 @@ int main(int argc, char *argv[]) {
         {NULL, no_argument, NULL, 0}
     };
 
-    if (username == NULL)
+    if (pw == NULL)
         err(EXIT_FAILURE, "getpwuid() failed");
+    if ((username = pw->pw_name) == NULL)
+        errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
     char *optstring = "hvnbdc:p:ui:teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {


### PR DESCRIPTION
Hi guys,
I've just had quite a problem with i3lock, I was not able to unlock…I was entering the correct password, that's for sure. The PAM configuration seems to be correct too.

The problem was with the `$USER` environmental value…see:

    $ echo $USER
    %{%{%}%}%n

That's not my username :) And because i3lock gets the username from that env value...it fails to unlock against wrong/non-existing user.

    ...
    if ((username = getenv("USER")) == NULL)
    ...

It's obvious I should first fix the wrong content of my `$USER`, and I'll do it, but I was also thinking that it might be a good idea to change how i3lock find out who is the current user of a session.
After a quick googling, I've found that it is easy to write own "whoami" function, so I did it and here is the pull request.

What do you think?
Btw, this is my first shot with C programming, although it's almost only copy-pasta job, maybe I did something wrong, I have to learn more for example about pointers :)
If you have any suggestion, I'll be happy to fix any problem there could be.

Thanks!