### PR TITLE
Feature: clock

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -23,12 +23,15 @@ i3lock \- improved screen locker
 .IR image.png \|]
 .RB [\|\-c
 .IR color \|]
+.RB [\|\-F
+.IR fgcolor \|]
 .RB [\|\-t\|]
 .RB [\|\-p
 .IR pointer\|]
 .RB [\|\-u\|]
 .RB [\|\-e\|]
 .RB [\|\-I\|]
+.RB [\|\-T\|]
 .RB [\|\-f\|]
 
 .SH DESCRIPTION
@@ -94,6 +97,10 @@ Turn the screen into the given color instead of white. Color must be given in 3-
 format: rrggbb (i.e. ff0000 is red).
 
 .TP
+.BI \-F\  rrggbb \fR,\ \fB\-\-fgcolor= rrggbb
+Sets the color used for text.
+
+.TP
 .B \-t, \-\-tiling
 If an image is specified (via \-i) it will display the image tiled all over the screen
 (if it is a multi-monitor setup, the image is visible on all screens).
@@ -115,6 +122,12 @@ and, if invalid, the user will have to wait a few seconds before
 another try. This can be useful if the XF86ScreenSaver key is used to
 put a laptop to sleep and bounce on resume or if you happen to wake up
 your computer with the enter key.
+
+.TP
+.B \-T, \-\-time
+Makes
+.B i3lock
+draw the current time in the middle of the screen.
 
 .TP
 .B \-f, \-\-show-failed-attempts

--- a/i3lock.c
+++ b/i3lock.c
@@ -836,8 +836,8 @@ int main(int argc, char *argv[]) {
             show_failed_attempts = true;
             break;
         default:
-            errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
-            " [-i image.png] [-t] [-e] [-I] [-f]"
+            errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c bgcolor] [-F fgcolor] [-u] [-p win|default]"
+            " [-i image.png] [-t] [-e] [-I] [-T] [-f]"
             );
         }
     }

--- a/i3lock.c
+++ b/i3lock.c
@@ -67,6 +67,7 @@ static struct ev_timer *clear_pam_wrong_timeout;
 static struct ev_timer *clear_indicator_timeout;
 static struct ev_timer *dpms_timeout;
 static struct ev_timer *discard_passwd_timeout;
+static struct ev_timer clock_timer;
 extern unlock_state_t unlock_state;
 extern pam_state_t pam_state;
 int failed_attempts = 0;
@@ -273,6 +274,10 @@ static void discard_passwd_cb(EV_P_ ev_timer *w, int revents) {
     clear_input();
     turn_monitors_off();
     STOP_TIMER(discard_passwd_timeout);
+}
+
+static void clock_tick_cb(EV_P_ ev_timer *w, int revents) {
+    redraw_screen();
 }
 
 static void input_done(void) {
@@ -983,6 +988,11 @@ int main(int argc, char *argv[]) {
     main_loop = EV_DEFAULT;
     if (main_loop == NULL)
         errx(EXIT_FAILURE, "Could not initialize libev. Bad LIBEV_FLAGS?\n");
+
+    if (showtime) {
+        ev_timer_init(&clock_timer, clock_tick_cb, 1.0, 1.0);
+        ev_timer_start(main_loop, &clock_timer);
+    }
 
     struct ev_io *xcb_watcher = calloc(sizeof(struct ev_io), 1);
     struct ev_check *xcb_check = calloc(sizeof(struct ev_check), 1);

--- a/i3lock.c
+++ b/i3lock.c
@@ -82,6 +82,7 @@ static uint8_t xkb_base_error;
 
 cairo_surface_t *img = NULL;
 bool tile = false;
+bool showtime = false;
 bool ignore_empty_password = false;
 bool skip_repeated_empty_password = false;
 
@@ -754,6 +755,7 @@ int main(int argc, char *argv[]) {
         {"no-unlock-indicator", no_argument, NULL, 'u'},
         {"image", required_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
+        {"time", no_argument, NULL, 'T'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
@@ -765,7 +767,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:F:p:ui:teI:f";
+    char *optstring = "hvnbdc:F:p:ui:teI:Tf";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
         case 'v':
@@ -805,6 +807,9 @@ int main(int argc, char *argv[]) {
             break;
         case 't':
             tile = true;
+            break;
+        case 'T':
+            showtime = true;
             break;
         case 'p':
             if (!strcmp(optarg, "win")) {

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -50,6 +50,8 @@ extern cairo_surface_t *img;
 
 /* Whether the image should be tiled. */
 extern bool tile;
+/* Whether we need to draw clock */
+extern bool showtime;
 /* The background and foreground color to use. */
 extern char color[7];
 extern uint8_t bgcolor[3], fgcolor[3];
@@ -132,32 +134,33 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         cairo_fill(xcb_ctx);
     }
 
-    /* Drawing the current time */
-    char text[20];
-    time_t t;
-    struct tm *tm;
+    if (showtime) {
+        /* Drawing the current time */
+        char text[20];
+        time_t t;
+        struct tm *tm;
 
-    t = time(NULL);
-    tm = localtime(&t);
-    if (strftime(text, sizeof(text), "%T", tm)) {
-        const int fontsz = 100;
-        cairo_text_extents_t extents;
-        double x, y;
+        t = time(NULL);
+        tm = localtime(&t);
+        if (strftime(text, sizeof(text), "%T", tm)) {
+            const int fontsz = 100;
+            cairo_text_extents_t extents;
+            double x, y;
 
-        cairo_select_font_face(xcb_ctx, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-        cairo_set_font_size (xcb_ctx, fontsz);
+            cairo_select_font_face(xcb_ctx, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+            cairo_set_font_size (xcb_ctx, fontsz);
 
-        //cairo_move_to (xcb_ctx, 10.0, 135.0);
+            //cairo_move_to (xcb_ctx, 10.0, 135.0);
 
-        cairo_text_extents(xcb_ctx, text, &extents);
-        x = resolution[0] / 2 - ((extents.width / 2) + extents.x_bearing);
-        y = resolution[1] / 2 - ((extents.height / 2) + extents.y_bearing);
+            cairo_text_extents(xcb_ctx, text, &extents);
+            x = resolution[0] / 2 - ((extents.width / 2) + extents.x_bearing);
+            y = resolution[1] / 2 - ((extents.height / 2) + extents.y_bearing);
 
-        cairo_move_to(xcb_ctx, x, y);
-        cairo_set_source_rgb (xcb_ctx, fgcolor[0] / 255.0, fgcolor[1] / 255.0, fgcolor[2] / 255.0);
-        cairo_show_text (xcb_ctx, text);
+            cairo_move_to(xcb_ctx, x, y);
+            cairo_set_source_rgb (xcb_ctx, fgcolor[0] / 255.0, fgcolor[1] / 255.0, fgcolor[2] / 255.0);
+            cairo_show_text (xcb_ctx, text);
+        }
     }
-
     if (unlock_state >= STATE_KEY_PRESSED && unlock_indicator) {
         cairo_scale(ctx, scaling_factor(), scaling_factor());
         /* Draw a (centered) circle with transparent background. */

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -50,8 +50,9 @@ extern cairo_surface_t *img;
 
 /* Whether the image should be tiled. */
 extern bool tile;
-/* The background color to use (in hex). */
+/* The background and foreground color to use. */
 extern char color[7];
+extern uint8_t bgcolor[3], fgcolor[3];
 
 /* Whether the failed attempts should be displayed. */
 extern bool show_failed_attempts;
@@ -126,13 +127,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
             cairo_pattern_destroy(pattern);
         }
     } else {
-        char strgroups[3][3] = {{color[0], color[1], '\0'},
-                                {color[2], color[3], '\0'},
-                                {color[4], color[5], '\0'}};
-        uint32_t rgb16[3] = {(strtol(strgroups[0], NULL, 16)),
-                             (strtol(strgroups[1], NULL, 16)),
-                             (strtol(strgroups[2], NULL, 16))};
-        cairo_set_source_rgb(xcb_ctx, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0);
+        cairo_set_source_rgb(xcb_ctx, bgcolor[0] / 255.0, bgcolor[1] / 255.0, bgcolor[2] / 255.0);
         cairo_rectangle(xcb_ctx, 0, 0, resolution[0], resolution[1]);
         cairo_fill(xcb_ctx);
     }
@@ -159,7 +154,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         y = resolution[1] / 2 - ((extents.height / 2) + extents.y_bearing);
 
         cairo_move_to(xcb_ctx, x, y);
-        cairo_set_source_rgb (xcb_ctx, 0, 0, 0);
+        cairo_set_source_rgb (xcb_ctx, fgcolor[0] / 255.0, fgcolor[1] / 255.0, fgcolor[2] / 255.0);
         cairo_show_text (xcb_ctx, text);
     }
 

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include <time.h>
 #include <xcb/xcb.h>
 #include <ev.h>
 #include <cairo.h>
@@ -134,6 +135,32 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         cairo_set_source_rgb(xcb_ctx, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0);
         cairo_rectangle(xcb_ctx, 0, 0, resolution[0], resolution[1]);
         cairo_fill(xcb_ctx);
+    }
+
+    /* Drawing the current time */
+    char text[20];
+    time_t t;
+    struct tm *tm;
+
+    t = time(NULL);
+    tm = localtime(&t);
+    if (strftime(text, sizeof(text), "%T", tm)) {
+        const int fontsz = 100;
+        cairo_text_extents_t extents;
+        double x, y;
+
+        cairo_select_font_face(xcb_ctx, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+        cairo_set_font_size (xcb_ctx, fontsz);
+
+        //cairo_move_to (xcb_ctx, 10.0, 135.0);
+
+        cairo_text_extents(xcb_ctx, text, &extents);
+        x = resolution[0] / 2 - ((extents.width / 2) + extents.x_bearing);
+        y = resolution[1] / 2 - ((extents.height / 2) + extents.y_bearing);
+
+        cairo_move_to(xcb_ctx, x, y);
+        cairo_set_source_rgb (xcb_ctx, 0, 0, 0);
+        cairo_show_text (xcb_ctx, text);
     }
 
     if (unlock_state >= STATE_KEY_PRESSED && unlock_indicator) {

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -150,9 +150,9 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
 
             /* frame spec */
             static double rx, ry, rw, rh;
-            const double lw = 6, spc = 15;
+            const double lw = 4, spc = 15;
 
-            cairo_set_font_size (xcb_ctx, fontsz);
+            cairo_set_font_size(xcb_ctx, fontsz);
             cairo_text_extents(xcb_ctx, text, &extents);
             /* avoid wobbling */
             if (fresh) {
@@ -167,17 +167,18 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
             }
 
             /* draw a frame */
-            cairo_set_source_rgb (xcb_ctx, bgcolor[0] / 255.0, bgcolor[1] / 255.0, bgcolor[2] / 255.0);
+            cairo_set_line_join(xcb_ctx, CAIRO_LINE_JOIN_ROUND);
+            cairo_set_source_rgb(xcb_ctx, bgcolor[0] / 255.0, bgcolor[1] / 255.0, bgcolor[2] / 255.0);
             cairo_rectangle(xcb_ctx, rx, ry, rw, rh);
             cairo_fill(xcb_ctx);
-            cairo_set_source_rgb (xcb_ctx, fgcolor[0] / 255.0, fgcolor[1] / 255.0, fgcolor[2] / 255.0);
+            cairo_set_source_rgb(xcb_ctx, fgcolor[0] / 255.0, fgcolor[1] / 255.0, fgcolor[2] / 255.0);
             cairo_set_line_width(xcb_ctx, lw);
             cairo_rectangle(xcb_ctx, rx, ry, rw, rh);
             cairo_stroke(xcb_ctx);
 
             /* draw the time */
             cairo_move_to(xcb_ctx, x, y);
-            cairo_show_text (xcb_ctx, text);
+            cairo_show_text(xcb_ctx, text);
         }
     }
     if (unlock_state >= STATE_KEY_PRESSED && unlock_indicator) {


### PR DESCRIPTION
This pull-request adds a neat clock on locked screen. You can turn it on with -T option, and select font color with -F option.
This feature can be useful, for example, when you just want to know what time it is waking in the middle of the night and have just a laptop nearby.
How it looks for me with -c 000000 -F 00ff00 and active unlock indicator:
![Screenshot](http://dump.bitcheese.net/files/orotejy/2015-03-04-025045_1366x768_scrot.png)