### PR TITLE
Update copyright notices and get rid of ranges

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -1,7 +1,7 @@
 /*
  * vim:ts=4:sw=4:expandtab
  *
- * © 2010-2013 Michael Stapelberg
+ * © 2010 Michael Stapelberg
  *
  * See LICENSE for licensing information
  *
@@ -793,7 +793,7 @@ int main(int argc, char *argv[]) {
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
             case 'v':
-                errx(EXIT_SUCCESS, "version " VERSION " © 2010-2012 Michael Stapelberg");
+                errx(EXIT_SUCCESS, "version " VERSION " © 2010 Michael Stapelberg");
             case 'n':
                 dont_fork = true;
                 break;

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -1,7 +1,7 @@
 /*
  * vim:ts=4:sw=4:expandtab
  *
- * © 2010-2014 Michael Stapelberg
+ * © 2010 Michael Stapelberg
  *
  * See LICENSE for licensing information
  *

--- a/xcb.c
+++ b/xcb.c
@@ -1,7 +1,7 @@
 /*
  * vim:ts=4:sw=4:expandtab
  *
- * © 2010-2012 Michael Stapelberg
+ * © 2010 Michael Stapelberg
  *
  * xcb.c: contains all functions which use XCB to talk to X11. Mostly wrappers
  *        around the rather complicated/ugly parts of the XCB API.

--- a/xinerama.c
+++ b/xinerama.c
@@ -1,7 +1,7 @@
 /*
  * vim:ts=4:sw=4:expandtab
  *
- * © 2010-2012 Michael Stapelberg
+ * © 2010 Michael Stapelberg
  *
  * See LICENSE for licensing information
  *


### PR DESCRIPTION
Though i3lock's commit history dates back to 2009, you did a ~100% rewrite of it and replaced the copyright notice with 2010, so I've kept that as-is — all that remains of the circa-2009 code is a few blank lines and a closing `*/` from a multi-line comment.