### PR TITLE
add options to set margins for fullscreen window

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -735,6 +735,10 @@ int main(int argc, char *argv[]) {
     struct passwd *pw;
     char *username;
     char *image_path = NULL;
+    int top_margin = 0;
+    int bottom_margin = 0;
+    int left_margin = 0;
+    int right_margin = 0;
     int ret;
     struct pam_conv conv = {conv_callback, NULL};
     int curs_choice = CURS_NONE;
@@ -755,6 +759,10 @@ int main(int argc, char *argv[]) {
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
+        {"top-margin", required_argument, NULL, 'T'},
+        {"bottom-margin", required_argument, NULL, 'B'},
+        {"left-margin", required_argument, NULL, 'L'},
+        {"right-margin", required_argument, NULL, 'R'},
         {NULL, no_argument, NULL, 0}};
 
     if ((pw = getpwuid(getuid())) == NULL)
@@ -822,6 +830,22 @@ int main(int argc, char *argv[]) {
                 break;
             case 'f':
                 show_failed_attempts = true;
+                break;
+            case 'T':
+                if (sscanf(optarg, "%d", &top_margin) != 1 || top_margin < 0)
+                    errx(EXIT_FAILURE, "invalid top margin, it must be a positive integer\n");
+                break;
+            case 'B':
+                if (sscanf(optarg, "%d", &bottom_margin) != 1 || bottom_margin < 0)
+                    errx(EXIT_FAILURE, "invalid bottom margin, it must be a positive integer\n");
+                break;
+            case 'L':
+                if (sscanf(optarg, "%d", &left_margin) != 1 || left_margin < 0)
+                    errx(EXIT_FAILURE, "invalid left margin, it must be a positive integer\n");
+                break;
+            case 'R':
+                if (sscanf(optarg, "%d", &right_margin) != 1 || right_margin < 0)
+                    errx(EXIT_FAILURE, "invalid right margin, it must be a positive integer\n");
                 break;
             default:
                 errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
@@ -932,7 +956,7 @@ int main(int argc, char *argv[]) {
     xcb_pixmap_t bg_pixmap = draw_image(last_resolution);
 
     /* open the fullscreen window, already with the correct pixmap in place */
-    win = open_fullscreen_window(conn, screen, color, bg_pixmap);
+    win = open_fullscreen_window(conn, screen, color, bg_pixmap, top_margin, bottom_margin, left_margin, right_margin);
     xcb_free_pixmap(conn, bg_pixmap);
 
     pid_t pid = fork();

--- a/xcb.c
+++ b/xcb.c
@@ -97,7 +97,7 @@ xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32
     return bg_pixmap;
 }
 
-xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap) {
+xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap, int top_margin, int bottom_margin, int left_margin, int right_margin) {
     uint32_t mask = 0;
     uint32_t values[3];
     xcb_window_t win = xcb_generate_id(conn);
@@ -124,9 +124,9 @@ xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, c
                       XCB_COPY_FROM_PARENT,
                       win,       /* the window id */
                       scr->root, /* parent == root */
-                      0, 0,
-                      scr->width_in_pixels,
-                      scr->height_in_pixels, /* dimensions */
+                      left_margin, top_margin,
+                      scr->width_in_pixels - left_margin - right_margin,
+                      scr->height_in_pixels - top_margin - bottom_margin, /* dimensions */
                       0,                     /* border = 0, we draw our own */
                       XCB_WINDOW_CLASS_INPUT_OUTPUT,
                       XCB_WINDOW_CLASS_COPY_FROM_PARENT, /* copy visual from parent */

--- a/xcb.h
+++ b/xcb.h
@@ -9,7 +9,7 @@ extern xcb_screen_t *screen;
 
 xcb_visualtype_t *get_root_visual_type(xcb_screen_t *s);
 xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, char *color);
-xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap);
+xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap, int top_margin, int bottom_margin, int left_margin, int right_margin);
 void grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor);
 void dpms_set_mode(xcb_connection_t *conn, xcb_dpms_dpms_mode_t mode);
 xcb_cursor_t create_cursor(xcb_connection_t *conn, xcb_screen_t *screen, xcb_window_t win, int choice);


### PR DESCRIPTION
This change adds four new options to set the top, left, right
and bottom margins of the fullscreen window. That is useful if
you want to have additional programs (such as docks) be visible
while the screen is locked.