### PR TITLE
Empty the event queue after pam fails to authenticate

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -303,6 +303,16 @@ static void input_done(void) {
     if (unlock_indicator)
         redraw_screen();
 
+    /* Skip all the events during the pam verification to avoid bad people
+     * spamming keys and locking pam in an endless validation loop */
+    xcb_generic_event_t *ev = xcb_poll_for_event(conn);
+    free(ev);
+    while (ev != NULL)
+    {
+        ev = xcb_poll_for_queued_event(conn);
+        free(ev);
+    }
+
     /* Clear this state after 2 seconds (unless the user enters another
      * password during that time). */
     ev_now_update(main_loop);


### PR DESCRIPTION
This avoids bad people repeating the "key + enter" combination, which puts
i3lock in a loop of pam validation delays and prevents the owner of the session
to log in properly before the whole queue is emptied.