### PR TITLE
Display time at the center of the unlock circle

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -30,6 +30,7 @@ i3lock \- improved screen locker
 .RB [\|\-I
 .IR timeout\|]
 .RB [\|\-f\|]
+.RB [\|\-C\|]
 
 .SH DESCRIPTION
 .B i3lock
@@ -113,6 +114,10 @@ your computer with the enter key.
 .TP
 .B \-f, \-\-show-failed-attempts
 Show the number of failed attempts, if any.
+
+.TP
+.B \-C, \-\-clock
+Displays a clock at the center of the status ring.
 
 .TP
 .B \-\-debug

--- a/i3lock.c
+++ b/i3lock.c
@@ -66,6 +66,7 @@ extern unlock_state_t unlock_state;
 extern pam_state_t pam_state;
 int failed_attempts = 0;
 bool show_failed_attempts = false;
+bool display_clock = false;
 
 static struct xkb_state *xkb_state;
 static struct xkb_context *xkb_context;
@@ -754,6 +755,7 @@ int main(int argc, char *argv[]) {
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
+        {"clock", no_argument, NULL, "C"},
         {NULL, no_argument, NULL, 0}};
 
     if ((pw = getpwuid(getuid())) == NULL)
@@ -761,7 +763,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:p:ui:teI:fC";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
             case 'v':
@@ -821,6 +823,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'f':
                 show_failed_attempts = true;
+                break;
+            case 'C':
+                display_clock = true;
                 break;
             default:
                 errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"

--- a/i3lock.c
+++ b/i3lock.c
@@ -755,7 +755,7 @@ int main(int argc, char *argv[]) {
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
-        {"clock", no_argument, NULL, "C"},
+        {"clock", no_argument, NULL, 'C'},
         {NULL, no_argument, NULL, 0}};
 
     if ((pw = getpwuid(getuid())) == NULL)

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -15,6 +15,7 @@
 #include <ev.h>
 #include <cairo.h>
 #include <cairo/cairo-xcb.h>
+#include <time.h>
 
 #include "i3lock.h"
 #include "xcb.h"
@@ -60,6 +61,9 @@ extern char color[7];
 extern bool show_failed_attempts;
 /* Number of failed unlock attempts. */
 extern int failed_attempts;
+
+/* Whether the clock shall be displayed. */
+extern int display_clock;
 
 /*******************************************************************************
  * Variables defined in xcb.c.
@@ -207,6 +211,21 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 text = "wrong!";
                 break;
             default:
+                if (display_clock) {
+                    time_t tm;
+
+                    tm = time(NULL);
+                    if (tm != ((time_t) -1)) {
+                        text = ctime(&tm);
+                        while (*text && *text != ':')
+                            ++text;
+                        if (*text && strlen(text) > 8) {
+                            text -= 2;
+                            text[8] = 0;
+                        }
+                    }
+                    cairo_set_source_rgb(ctx, 0.75, 0.75, 0.75);
+                }
                 if (show_failed_attempts && failed_attempts > 0) {
                     if (failed_attempts > 999) {
                         text = "> 999";

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -211,21 +211,6 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 text = "wrong!";
                 break;
             default:
-                if (display_clock) {
-                    time_t tm;
-
-                    tm = time(NULL);
-                    if (tm != ((time_t) -1)) {
-                        text = ctime(&tm);
-                        while (*text && *text != ':')
-                            ++text;
-                        if (*text && strlen(text) > 8) {
-                            text -= 2;
-                            text[8] = 0;
-                        }
-                    }
-                    cairo_set_source_rgb(ctx, 0.75, 0.75, 0.75);
-                }
                 if (show_failed_attempts && failed_attempts > 0) {
                     if (failed_attempts > 999) {
                         text = "> 999";
@@ -247,12 +232,48 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
             x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
             y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing);
 
+            if (display_clock && pam_state == STATE_PAM_IDLE) {
+                y += (extents.height);
+            }
+
             cairo_move_to(ctx, x, y);
             cairo_show_text(ctx, text);
             cairo_close_path(ctx);
         }
 
+        if (display_clock && pam_state == STATE_PAM_IDLE) {
+            char *time_ptr = NULL;
+            time_t tm;
+
+            tm = time(NULL);
+            if (tm != ((time_t) -1)) {
+                time_ptr = ctime(&tm);
+                while (*time_ptr && *time_ptr != ':')
+                    ++time_ptr;
+                if (*time_ptr && strlen(time_ptr) > 5) {
+                    time_ptr -= 2;
+                    time_ptr[5] = '\0';
+                }
+            }
+            cairo_set_font_size(ctx, 28.0);
+            cairo_set_source_rgb(ctx, 0.75, 0.75, 0.75);
+            cairo_text_extents_t extents;
+            double x, y;
+
+            cairo_text_extents(ctx, time_ptr, &extents);
+            x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
+            y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing);
+            if (text) {
+                y -= (extents.height);
+            }
+
+            cairo_move_to(ctx, x, y);
+            cairo_show_text(ctx, time_ptr);
+            cairo_close_path(ctx);
+        }
+
         if (pam_state == STATE_PAM_WRONG && (modifier_string != NULL)) {
+
             cairo_text_extents_t extents;
             double x, y;
 


### PR DESCRIPTION
How frustrating to have to unlock the screen only to look at the time! I thus added this simple option (-C or --clock) to only have to press a key to get the time.