### PR TITLE
Increase performance when having alpha channel in png image

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -116,8 +116,10 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
 
     if (img) {
         if (!tile) {
+            cairo_set_operator(xcb_ctx, CAIRO_OPERATOR_SOURCE);
             cairo_set_source_surface(xcb_ctx, img, 0, 0);
             cairo_paint(xcb_ctx);
+            cairo_set_operator(xcb_ctx, CAIRO_OPERATOR_OVER);
         } else {
             /* create a pattern and fill a rectangle as big as the screen */
             cairo_pattern_t *pattern;


### PR DESCRIPTION
I had pretty big performance issues with i3lock on my laptop. Turns out that it's caused by PNGs with an alpha channel. By changing the operator when rendering the PNG the alpha channel is ignored and we get high performance.

I have only tested this code on my machine but it works well. CAIRO_OPERATOR_OVER is the default operator.