### PR TITLE
Added a command-line option to resize the background image

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -93,6 +93,11 @@ If an image is specified (via \-i) it will display the image tiled all over the 
 (if it is a multi-monitor setup, the image is visible on all screens).
 
 .TP
+.B \-s, \-\-stretch
+If an image is specified (via \-i) it will resize the image to fit the screen
+(if it is a multi-monitor setup, the image fills all screens as if they were one).
+
+.TP
 .BI \-p\  win|default \fR,\ \fB\-\-pointer= win|default
 If you specify "default",
 .B i3lock


### PR DESCRIPTION
This patch allows the user to specify an option to resize the brackground image to completely fill the screen. At its current state when used with multi-monitor setup this will stretch the image across all screens, which may not be appropriate.