### PR TITLE
Read PNG from stdin when no argument is given

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -19,7 +19,7 @@ i3lock \- improved screen locker
 .RB [\|\-n\|]
 .RB [\|\-b\|]
 .RB [\|\-i
-.IR image.png \|]
+.IR [image.png \|]]
 .RB [\|\-c
 .IR color \|]
 .RB [\|\-t\|]
@@ -79,8 +79,9 @@ show you the current PAM state (whether your password is currently being
 verified or whether it is wrong).
 
 .TP
-.BI \-i\  path \fR,\ \fB\-\-image= path
-Display the given PNG image instead of a blank screen.
+.BI \-i\  [path] \fR,\ \fB\-\-image[= path]
+Display the given PNG image instead of a blank screen. When no image is
+specified, read from stdin.
 
 .TP
 .BI \-c\  rrggbb \fR,\ \fB\-\-color= rrggbb

--- a/i3lock.c
+++ b/i3lock.c
@@ -743,6 +743,13 @@ static void raise_loop(xcb_window_t window) {
     }
 }
 
+cairo_status_t img_read(void *closure, unsigned char *data,
+                        unsigned int length) {
+    return fread(data, 1, length, stdin) == length ? CAIRO_STATUS_SUCCESS
+                                                   : CAIRO_STATUS_READ_ERROR;
+    (void)closure;
+}
+
 int main(int argc, char *argv[]) {
     struct passwd *pw;
     char *username;
@@ -762,7 +769,7 @@ int main(int argc, char *argv[]) {
         {"debug", no_argument, NULL, 0},
         {"help", no_argument, NULL, 'h'},
         {"no-unlock-indicator", no_argument, NULL, 'u'},
-        {"image", required_argument, NULL, 'i'},
+        {"image", optional_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
@@ -774,7 +781,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:p:ui::teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
             case 'v':
@@ -811,7 +818,10 @@ int main(int argc, char *argv[]) {
                 unlock_indicator = false;
                 break;
             case 'i':
-                image_path = strdup(optarg);
+                if (optarg == NULL)
+                    image_path = "";
+                else
+                    image_path = strdup(optarg);
                 break;
             case 't':
                 tile = true;
@@ -933,7 +943,11 @@ int main(int argc, char *argv[]) {
 
     if (image_path) {
         /* Create a pixmap to render on, fill it with the background color */
-        img = cairo_image_surface_create_from_png(image_path);
+        if (strlen(image_path) == 0)
+            img = cairo_image_surface_create_from_png_stream(img_read, NULL);
+        else
+            img = cairo_image_surface_create_from_png(image_path);
+
         /* In case loading failed, we just pretend no -i was specified. */
         if (cairo_surface_status(img) != CAIRO_STATUS_SUCCESS) {
             fprintf(stderr, "Could not load image \"%s\": %s\n",

--- a/i3lock.c
+++ b/i3lock.c
@@ -819,7 +819,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'i':
                 if (optarg == NULL)
-                    image_path = "";
+                    image_path = strdup("");
                 else
                     image_path = strdup(optarg);
                 break;
@@ -847,7 +847,7 @@ int main(int argc, char *argv[]) {
                 break;
             default:
                 errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
-                                   " [-i image.png] [-t] [-e] [-I timeout] [-f]");
+                                   " [-i [image.png]] [-t] [-e] [-I timeout] [-f]");
         }
     }
 


### PR DESCRIPTION
This removes the need for intermediate files or hacky things like `/dev/stdin`. By changing `-i` to be optional and reading from stdin when no argument is given.

For example the following usecase, a blurred screenshot as lock image:
```
import -window root -resize 50% -resize 200% png:- | i3lock -i
```