### PR TITLE
add -s/--scaled option to scale the image on all available screens

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -84,6 +84,11 @@ If an image is specified (via \-i) it will display the image tiled all over the 
 (if it is a multi-monitor setup, the image is visible on all screens).
 
 .TP
+.B \-s, \-\-scaled
+If an image is specified (via \-i) it will display the image scaled on each
+available screen.
+
+.TP
 .BI \-p\  win|default \fR,\ \fB\-\-pointer= win|default
 If you specify "default",
 .B i3lock

--- a/i3lock.c
+++ b/i3lock.c
@@ -76,6 +76,7 @@ static uint8_t xkb_base_error;
 
 cairo_surface_t *img = NULL;
 bool tile = false;
+bool scaled = false;
 bool ignore_empty_password = false;
 bool skip_repeated_empty_password = false;
 
@@ -780,6 +781,7 @@ int main(int argc, char *argv[]) {
         {"no-unlock-indicator", no_argument, NULL, 'u'},
         {"image", required_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
+        {"scaled", no_argument, NULL, 's'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
@@ -790,7 +792,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:p:ui:teI:fs";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
             case 'v':
@@ -828,6 +830,15 @@ int main(int argc, char *argv[]) {
                 break;
             case 't':
                 tile = true;
+                if (scaled) {
+                    errx(EXIT_FAILURE, "the tile and scaled option can not be used at the same time\n");
+                }
+                break;
+            case 's':
+                scaled = true;
+                if (tile) {
+                    errx(EXIT_FAILURE, "the tile and scaled option can not be used at the same time\n");
+                }
                 break;
             case 'p':
                 if (!strcmp(optarg, "win")) {


### PR DESCRIPTION
I was not satisfied with the image options and decided to add on to scale the input image on all screens. Without `-t`, the image is only displayed as-is.
This new option is incompatible with the `-t` option.