### PR TITLE
Displaying locking message when grabbing the pointer.

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -156,6 +156,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
          * (currently verifying, wrong password, or default) */
         switch (pam_state) {
             case STATE_PAM_VERIFY:
+            case STATE_PAM_LOCK:
                 cairo_set_source_rgba(ctx, 0, 114.0 / 255, 255.0 / 255, 0.75);
                 break;
             case STATE_PAM_WRONG:
@@ -169,6 +170,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
 
         switch (pam_state) {
             case STATE_PAM_VERIFY:
+            case STATE_PAM_LOCK:
                 cairo_set_source_rgb(ctx, 51.0 / 255, 0, 250.0 / 255);
                 break;
             case STATE_PAM_WRONG:
@@ -204,6 +206,9 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         switch (pam_state) {
             case STATE_PAM_VERIFY:
                 text = "verifying…";
+                break;
+            case STATE_PAM_LOCK:
+                text = "locking…";
                 break;
             case STATE_PAM_WRONG:
                 text = "wrong!";

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -13,7 +13,8 @@ typedef enum {
 typedef enum {
     STATE_PAM_IDLE = 0,   /* no PAM interaction at the moment */
     STATE_PAM_VERIFY = 1, /* currently verifying the password via PAM */
-    STATE_PAM_WRONG = 2   /* the password was wrong */
+    STATE_PAM_LOCK = 2,   /* currently locking the screen */
+    STATE_PAM_WRONG = 3   /* the password was wrong */
 } pam_state_t;
 
 xcb_pixmap_t draw_image(uint32_t* resolution);


### PR DESCRIPTION
This PR fixes #36. Instead of waiting 250 ms to display the "locking…" message, I propose to display it right away since `START_TIMER` won't work when grabbing the pointer. However, I added a timer to hide the message after 250 ms in case of success. It actually makes sense to me to display the locking message each time.

Also, I shifted fork code down so the return value will actually be 1 in case of failure to grab the pointer.