### PR TITLE
Set font face

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -199,6 +199,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         char buf[4];
 
         cairo_set_source_rgb(ctx, 0, 0, 0);
+        cairo_select_font_face(ctx, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
         cairo_set_font_size(ctx, 28.0);
         switch (pam_state) {
             case STATE_PAM_VERIFY:


### PR DESCRIPTION
I've run into the default locking font being TeX Gyre Chorus on my system and found out after debugging with `FC_DEBUG=4096` that i3lock is not specifying any family name at all.  According to the docs the default is usually a sans-serif font, however it's a bit irksome to rely on this behavior.  Setting the font explicitly solves this.