### PR TITLE
Fix covering of composited notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     - libev-dev
     - libxcb-xinerama0-dev
     - libxcb-xkb-dev
+    - libxcb-composite0-dev
 before_install:
   - "echo 'APT::Default-Release \"trusty\";' | sudo tee /etc/apt/apt.conf.d/default-release"
   - "echo 'deb http://archive.ubuntu.com/ubuntu/ wily main universe' | sudo tee /etc/apt/sources.list.d/wily.list"

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ CFLAGS += -std=c99
 CFLAGS += -pipe
 CFLAGS += -Wall
 CPPFLAGS += -D_GNU_SOURCE
-CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
-LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
+CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-composite xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
+LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-composite xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += -lpam
 LIBS += -lev
 LIBS += -lm

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Requirements
 - libxcb-util
 - libpam-dev
 - libcairo-dev
+- libxcb-composite0
 - libxcb-xinerama
 - libev
 - libx11-dev

--- a/xcb.c
+++ b/xcb.c
@@ -11,6 +11,7 @@
 #include <xcb/xcb_image.h>
 #include <xcb/xcb_atom.h>
 #include <xcb/xcb_aux.h>
+#include <xcb/composite.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -102,6 +103,29 @@ xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, c
     uint32_t mask = 0;
     uint32_t values[3];
     xcb_window_t win = xcb_generate_id(conn);
+    xcb_window_t parent_win = scr->root;
+
+    /* Check whether the composite extension is available */
+    const xcb_query_extension_reply_t *extension_query = NULL;
+    xcb_generic_error_t *error = NULL;
+    xcb_composite_get_overlay_window_cookie_t cookie;
+    xcb_composite_get_overlay_window_reply_t *composite_reply = NULL;
+
+    extension_query = xcb_get_extension_data(conn, &xcb_composite_id);
+    if (extension_query && extension_query->present) {
+        /* When composition is used, we need to use the composite overlay
+         * window instead of the normal root window to be able to cover
+         * composited windows */
+        cookie = xcb_composite_get_overlay_window(conn, scr->root);
+        composite_reply = xcb_composite_get_overlay_window_reply(conn, cookie, &error);
+
+        if (!error && composite_reply) {
+            parent_win = composite_reply->overlay_win;
+        }
+
+        free(composite_reply);
+        free(error);
+    }
 
     if (pixmap == XCB_NONE) {
         mask |= XCB_CW_BACK_PIXEL;
@@ -123,8 +147,8 @@ xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, c
 
     xcb_create_window(conn,
                       XCB_COPY_FROM_PARENT,
-                      win,       /* the window id */
-                      scr->root, /* parent == root */
+                      win, /* the window id */
+                      parent_win,
                       0, 0,
                       scr->width_in_pixels,
                       scr->height_in_pixels, /* dimensions */


### PR DESCRIPTION
Use the XComposite extension to get the composite overlay window,
instead of just using the normal root window. This ensures that
composited windows are covered.

Fixes issue #22 
