### PR TITLE
Display error message when locking failed

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -160,6 +160,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 cairo_set_source_rgba(ctx, 0, 114.0 / 255, 255.0 / 255, 0.75);
                 break;
             case STATE_PAM_WRONG:
+            case STATE_I3LOCK_LOCK_FAILED:
                 cairo_set_source_rgba(ctx, 250.0 / 255, 0, 0, 0.75);
                 break;
             default:
@@ -174,6 +175,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 cairo_set_source_rgb(ctx, 51.0 / 255, 0, 250.0 / 255);
                 break;
             case STATE_PAM_WRONG:
+            case STATE_I3LOCK_LOCK_FAILED:
                 cairo_set_source_rgb(ctx, 125.0 / 255, 51.0 / 255, 0);
                 break;
             case STATE_PAM_IDLE:
@@ -212,6 +214,9 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 break;
             case STATE_PAM_WRONG:
                 text = "wrong!";
+                break;
+            case STATE_I3LOCK_LOCK_FAILED:
+                text = "lock failed!";
                 break;
             default:
                 if (show_failed_attempts && failed_attempts > 0) {

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -11,10 +11,11 @@ typedef enum {
 } unlock_state_t;
 
 typedef enum {
-    STATE_PAM_IDLE = 0,   /* no PAM interaction at the moment */
-    STATE_PAM_VERIFY = 1, /* currently verifying the password via PAM */
-    STATE_PAM_LOCK = 2,   /* currently locking the screen */
-    STATE_PAM_WRONG = 3   /* the password was wrong */
+    STATE_PAM_IDLE = 0,          /* no PAM interaction at the moment */
+    STATE_PAM_VERIFY = 1,        /* currently verifying the password via PAM */
+    STATE_PAM_LOCK = 2,          /* currently locking the screen */
+    STATE_PAM_WRONG = 3,         /* the password was wrong */
+    STATE_I3LOCK_LOCK_FAILED = 4 /* i3lock failed to load */
 } pam_state_t;
 
 xcb_pixmap_t draw_image(uint32_t* resolution);

--- a/xcb.c
+++ b/xcb.c
@@ -23,6 +23,8 @@
 #include "cursors.h"
 #include "unlock_indicator.h"
 
+extern pam_state_t pam_state;
+
 xcb_connection_t *conn;
 xcb_screen_t *screen;
 
@@ -160,7 +162,7 @@ xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, c
 }
 
 /*
- * Repeatedly tries to grab pointer and keyboard (up to 1000 times).
+ * Repeatedly tries to grab pointer and keyboard (up to 10000 times).
  *
  */
 void grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor) {
@@ -233,8 +235,14 @@ void grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb
         }
     }
 
-    if (tries <= 0)
+    /* After trying for 10000 times, i3lock will display an error message
+     * for 2 sec prior to terminate. */
+    if (tries <= 0) {
+        pam_state = STATE_I3LOCK_LOCK_FAILED;
+        redraw_screen();
+        sleep(1);
         errx(EXIT_FAILURE, "Cannot grab pointer/keyboard");
+    }
 }
 
 xcb_cursor_t create_cursor(xcb_connection_t *conn, xcb_screen_t *screen, xcb_window_t win, int choice) {


### PR DESCRIPTION
This PR is an attempt to address issue #98, displaying an error message before exiting when the pointer couldn't be grabbed and then the locking failed.

There's currently a problem with the text size that overflows the circle, I need to figure out how to split the text between two lines…