### PR TITLE
Provide option to hide the PAM state text on the unlock indicator

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -70,6 +70,10 @@ show you the current PAM state (whether your password is currently being
 verified or whether it is wrong).
 
 .TP
+.B \-x, \-\-no-text
+Hide the PAM state text on the unlock indicator.
+
+.TP
 .BI \-i\  path \fR,\ \fB\-\-image= path
 Display the given PNG image instead of a blank screen.
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -56,6 +56,7 @@ static char password[512];
 static bool beep = false;
 bool debug_mode = false;
 bool unlock_indicator = true;
+bool pam_state_text = true;
 char *modifier_string = NULL;
 static bool dont_fork = false;
 struct ev_loop *main_loop;
@@ -797,6 +798,7 @@ int main(int argc, char *argv[]) {
         {"debug", no_argument, NULL, 0},
         {"help", no_argument, NULL, 'h'},
         {"no-unlock-indicator", no_argument, NULL, 'u'},
+        {"no-text", no_argument, NULL, 'x'},
         {"image", required_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
@@ -809,7 +811,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:p:uxi:teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
             case 'v':
@@ -842,6 +844,9 @@ int main(int argc, char *argv[]) {
             case 'u':
                 unlock_indicator = false;
                 break;
+            case 'x':
+                pam_state_text = false;
+                break;
             case 'i':
                 image_path = strdup(optarg);
                 break;
@@ -868,7 +873,7 @@ int main(int argc, char *argv[]) {
                 show_failed_attempts = true;
                 break;
             default:
-                errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
+                errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-x] [-p win|default]"
                                    " [-i image.png] [-t] [-e] [-I timeout] [-f]");
         }
     }

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -45,6 +45,9 @@ extern uint32_t last_resolution[2];
 /* Whether the unlock indicator is enabled (defaults to true). */
 extern bool unlock_indicator;
 
+/* Whether the PAM state text is displayed (defaults to true). */
+extern bool pam_state_text;
+
 /* List of pressed modifiers, or NULL if none are pressed. */
 extern char *modifier_string;
 
@@ -202,62 +205,64 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         /* We don't want to show more than a 3-digit number. */
         char buf[4];
 
-        cairo_set_source_rgb(ctx, 0, 0, 0);
-        cairo_select_font_face(ctx, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-        cairo_set_font_size(ctx, 28.0);
-        switch (pam_state) {
-            case STATE_PAM_VERIFY:
-                text = "verifying…";
-                break;
-            case STATE_PAM_LOCK:
-                text = "locking…";
-                break;
-            case STATE_PAM_WRONG:
-                text = "wrong!";
-                break;
-            case STATE_I3LOCK_LOCK_FAILED:
-                text = "lock failed!";
-                break;
-            default:
-                if (show_failed_attempts && failed_attempts > 0) {
-                    if (failed_attempts > 999) {
-                        text = "> 999";
-                    } else {
-                        snprintf(buf, sizeof(buf), "%d", failed_attempts);
-                        text = buf;
-                    }
-                    cairo_set_source_rgb(ctx, 1, 0, 0);
-                    cairo_set_font_size(ctx, 32.0);
-                }
-                break;
-        }
+        if (pam_state_text) {
+          cairo_set_source_rgb(ctx, 0, 0, 0);
+          cairo_select_font_face(ctx, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+          cairo_set_font_size(ctx, 28.0);
+          switch (pam_state) {
+              case STATE_PAM_VERIFY:
+                  text = "verifying…";
+                  break;
+              case STATE_PAM_LOCK:
+                  text = "locking…";
+                  break;
+              case STATE_PAM_WRONG:
+                  text = "wrong!";
+                  break;
+              case STATE_I3LOCK_LOCK_FAILED:
+                  text = "lock failed!";
+                  break;
+              default:
+                  if (show_failed_attempts && failed_attempts > 0) {
+                      if (failed_attempts > 999) {
+                          text = "> 999";
+                      } else {
+                          snprintf(buf, sizeof(buf), "%d", failed_attempts);
+                          text = buf;
+                      }
+                      cairo_set_source_rgb(ctx, 1, 0, 0);
+                      cairo_set_font_size(ctx, 32.0);
+                  }
+                  break;
+          }
 
-        if (text) {
-            cairo_text_extents_t extents;
-            double x, y;
+          if (text) {
+              cairo_text_extents_t extents;
+              double x, y;
 
-            cairo_text_extents(ctx, text, &extents);
-            x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
-            y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing);
+              cairo_text_extents(ctx, text, &extents);
+              x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
+              y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing);
 
-            cairo_move_to(ctx, x, y);
-            cairo_show_text(ctx, text);
-            cairo_close_path(ctx);
-        }
+              cairo_move_to(ctx, x, y);
+              cairo_show_text(ctx, text);
+              cairo_close_path(ctx);
+          }
 
-        if (pam_state == STATE_PAM_WRONG && (modifier_string != NULL)) {
-            cairo_text_extents_t extents;
-            double x, y;
+          if (pam_state == STATE_PAM_WRONG && (modifier_string != NULL)) {
+              cairo_text_extents_t extents;
+              double x, y;
 
-            cairo_set_font_size(ctx, 14.0);
+              cairo_set_font_size(ctx, 14.0);
 
-            cairo_text_extents(ctx, modifier_string, &extents);
-            x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
-            y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing) + 28.0;
+              cairo_text_extents(ctx, modifier_string, &extents);
+              x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
+              y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing) + 28.0;
 
-            cairo_move_to(ctx, x, y);
-            cairo_show_text(ctx, modifier_string);
-            cairo_close_path(ctx);
+              cairo_move_to(ctx, x, y);
+              cairo_show_text(ctx, modifier_string);
+              cairo_close_path(ctx);
+          }
         }
 
         /* After the user pressed any valid key or the backspace key, we


### PR DESCRIPTION
I found myself really wanting to customize the text (default sans-serif looks mediocre on my machine).

However, in lieu of wanting to bring in pango or overcomplicate the text rendering in some other way, I found I'm also pretty happy with just killing the text altogether. But, I want to be able to keep the unlock indicator around to have some kind of feedback still.

Common enough case for upstream or am I the only one? :wink: 