### PR TITLE
Change input slices to be exactly pi/3 in size instead of slightly more

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -296,8 +296,8 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                       BUTTON_CENTER /* x */,
                       BUTTON_CENTER /* y */,
                       BUTTON_RADIUS /* radius */,
-                      highlight_start + (M_PI / 3.0) /* start */,
-                      (highlight_start + (M_PI / 3.0)) + (M_PI / 128.0) /* end */);
+                      (highlight_start + (M_PI / 3.0)) - (M_PI / 128.0) /* start */,
+                      highlight_start + (M_PI / 3.0) /* end */);
             cairo_stroke(ctx);
         }
     }


### PR DESCRIPTION
This changes the way separator lines are drawn on input slices. Now the separator lines overwrite the slice on both sides so that the slice is exactly π/3 in size.

As it is now, slices are (131 π)/384 in size because the less clockwise separator is drawn overwriting part of the slice, and the more clockwise separator is drawn past the end of the slice, extending it by π/128.