### PR TITLE
Command line option to center image

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -23,6 +23,7 @@ i3lock \- improved screen locker
 .RB [\|\-c
 .IR color \|]
 .RB [\|\-t\|]
+.RB [\|\-m\|]
 .RB [\|\-p
 .IR pointer\|]
 .RB [\|\-u\|]
@@ -82,6 +83,10 @@ format: rrggbb (i.e. ff0000 is red).
 .B \-t, \-\-tiling
 If an image is specified (via \-i) it will display the image tiled all over the screen
 (if it is a multi-monitor setup, the image is visible on all screens).
+
+.TP
+.B \-m, \-\-middle
+If an image is specified (via \-i) it will display the image centered on every screen.
 
 .TP
 .BI \-p\  win|default \fR,\ \fB\-\-pointer= win|default

--- a/i3lock.c
+++ b/i3lock.c
@@ -78,6 +78,7 @@ static uint8_t xkb_base_error;
 
 cairo_surface_t *img = NULL;
 bool tile = false;
+bool img_centered = false;
 bool ignore_empty_password = false;
 bool skip_repeated_empty_password = false;
 
@@ -799,6 +800,7 @@ int main(int argc, char *argv[]) {
         {"no-unlock-indicator", no_argument, NULL, 'u'},
         {"image", required_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
+        {"middle", no_argument, NULL, 'm'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
@@ -809,7 +811,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:p:ui:tmeI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
         switch (o) {
             case 'v':
@@ -848,6 +850,9 @@ int main(int argc, char *argv[]) {
             case 't':
                 tile = true;
                 break;
+            case 'm':
+                img_centered = true;
+                break;
             case 'p':
                 if (!strcmp(optarg, "win")) {
                     curs_choice = CURS_WIN;
@@ -869,7 +874,7 @@ int main(int argc, char *argv[]) {
                 break;
             default:
                 errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
-                                   " [-i image.png] [-t] [-e] [-I timeout] [-f]");
+                                   " [-i image.png] [-t] [-m] [-e] [-I timeout] [-f]");
         }
     }
 

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -53,6 +53,10 @@ extern cairo_surface_t *img;
 
 /* Whether the image should be tiled. */
 extern bool tile;
+
+/* Whether the image should be centered */
+extern bool img_centered;
+
 /* The background color to use (in hex). */
 extern char color[7];
 
@@ -116,8 +120,18 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
 
     if (img) {
         if (!tile) {
-            cairo_set_source_surface(xcb_ctx, img, 0, 0);
-            cairo_paint(xcb_ctx);
+            if (img_centered) {
+                /* Composite the image in the middle of each screen. */
+                for (int screen = 0; screen < xr_screens; screen++) {
+                    int x = (xr_resolutions[screen].x + ((xr_resolutions[screen].width / 2) - (cairo_image_surface_get_width(img) / 2)));
+                    int y = (xr_resolutions[screen].y + ((xr_resolutions[screen].height / 2) - (cairo_image_surface_get_height(img) / 2)));
+					cairo_set_source_surface(xcb_ctx, img, x, y);
+					cairo_paint(xcb_ctx);
+				}
+			} else {
+				cairo_set_source_surface(xcb_ctx, img, 0, 0);
+				cairo_paint(xcb_ctx);
+			}
         } else {
             /* create a pattern and fill a rectangle as big as the screen */
             cairo_pattern_t *pattern;

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -125,13 +125,13 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 for (int screen = 0; screen < xr_screens; screen++) {
                     int x = (xr_resolutions[screen].x + ((xr_resolutions[screen].width / 2) - (cairo_image_surface_get_width(img) / 2)));
                     int y = (xr_resolutions[screen].y + ((xr_resolutions[screen].height / 2) - (cairo_image_surface_get_height(img) / 2)));
-					cairo_set_source_surface(xcb_ctx, img, x, y);
-					cairo_paint(xcb_ctx);
-				}
-			} else {
-				cairo_set_source_surface(xcb_ctx, img, 0, 0);
-				cairo_paint(xcb_ctx);
-			}
+                    cairo_set_source_surface(xcb_ctx, img, x, y);
+                    cairo_paint(xcb_ctx);
+                
+            } else {
+                cairo_set_source_surface(xcb_ctx, img, 0, 0);
+                cairo_paint(xcb_ctx);
+            }
         } else {
             /* create a pattern and fill a rectangle as big as the screen */
             cairo_pattern_t *pattern;


### PR DESCRIPTION
This PR add a command line option to display the background image centered on every connected screen.
This allows for some fancy things like displaying a round logo inside the unlock circle and whatever you can come up with.
I chose to call the option "middle" [-m], because [-c] was already taken by "color".