### PR TITLE
Add man page installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PREFIX=/usr
 SYSCONFDIR=/etc
 PKG_CONFIG=pkg-config
 
+ifndef MANPREFIX
+  MANPREFIX=$(PREFIX)
+endif
+
 # Check if pkg-config is installed, we need it for building CFLAGS/LIBS
 ifeq ($(shell which $(PKG_CONFIG) 2>/dev/null 1>/dev/null || echo 1),1)
 $(error "$(PKG_CONFIG) was not found")
@@ -46,8 +50,10 @@ clean:
 install: all
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -d $(DESTDIR)$(SYSCONFDIR)/pam.d
+	$(INSTALL) -d $(DESTDIR)$(MANPREFIX)/share/man/man1
 	$(INSTALL) -m 755 i3lock $(DESTDIR)$(PREFIX)/bin/i3lock
 	$(INSTALL) -m 644 i3lock.pam $(DESTDIR)$(SYSCONFDIR)/pam.d/i3lock
+	$(INSTALL) -m 644 i3lock.1* $(DESTDIR)$(MANPREFIX)/share/man/man1
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/i3lock


### PR DESCRIPTION
Add missing i3lock.1 manual page to install section of Makefile.

I am not sure, if MANPREFIX is necessary, since I copied this part from i3status Makefile. So, please feel free to remove it.

However, please leave `*` symbol right after `i3lock.1` on line 56, because some build systems of linux distros compress man pages between `make` and `make install` stage. So, if you remove `*`, maintainers of these distributions will have to patch `Makefile`, replacing `i3lock.1` with something like `i3lock.1.bz` or `i3lock.1.xz`.