### PR TITLE
Remove last traces of DPMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ CFLAGS += -std=c99
 CFLAGS += -pipe
 CFLAGS += -Wall
 CPPFLAGS += -D_GNU_SOURCE
-CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-composite xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
-LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-composite xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
+CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-composite xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
+LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-composite xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += -lpam
 LIBS += -lev
 LIBS += -lm

--- a/xcb.h
+++ b/xcb.h
@@ -2,7 +2,6 @@
 #define _XCB_H
 
 #include <xcb/xcb.h>
-#include <xcb/dpms.h>
 
 extern xcb_connection_t *conn;
 extern xcb_screen_t *screen;
@@ -11,7 +10,6 @@ xcb_visualtype_t *get_root_visual_type(xcb_screen_t *s);
 xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, char *color);
 xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap);
 void grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor);
-void dpms_set_mode(xcb_connection_t *conn, xcb_dpms_dpms_mode_t mode);
 xcb_cursor_t create_cursor(xcb_connection_t *conn, xcb_screen_t *screen, xcb_window_t win, int choice);
 
 #endif


### PR DESCRIPTION
Since DPMS support was removed in 2.8, these last bits shouldn't be needed anymore.