### PR TITLE
Add support for bsd_auth(3) as authentication backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TOPDIR=$(shell pwd)
+UNAME=$(shell uname)
 
 INSTALL=install
 PREFIX=/usr
@@ -14,12 +15,15 @@ CFLAGS += -std=c99
 CFLAGS += -pipe
 CFLAGS += -Wall
 CPPFLAGS += -D_GNU_SOURCE
-CPPFLAGS += -DUSE_PAM
 CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-composite xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-composite xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
-LIBS += -lpam
 LIBS += -lev
 LIBS += -lm
+
+# OpenBSD lacks PAM, use bsd_auth(3) instead.
+ifneq ($(UNAME),OpenBSD)
+  LIBS += -lpam
+endif
 
 FILES:=$(wildcard *.c)
 FILES:=$(FILES:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CFLAGS += -std=c99
 CFLAGS += -pipe
 CFLAGS += -Wall
 CPPFLAGS += -D_GNU_SOURCE
+CPPFLAGS += -DUSE_PAM
 CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-composite xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-composite xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += -lpam

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Many little improvements have been made to i3lock over time:
 - You can specify whether i3lock should bell upon a wrong password.
 
 - i3lock uses PAM and therefore is compatible with LDAP etc.
+  On OpenBSD i3lock uses the bsd_auth(3) framework.
 
 Requirements
 ------------
@@ -36,6 +37,9 @@ Running i3lock
 -------------
 Simply invoke the 'i3lock' command. To get out of it, enter your password and
 press enter.
+
+On OpenBSD the `i3lock` binary needs to be setgid `auth` to call the
+authentication helpers, e.g. `/usr/libexec/auth/login_passwd`.
 
 Upstream
 --------

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -78,7 +78,7 @@ static xcb_visualtype_t *vistype;
 /* Maintain the current unlock/PAM state to draw the appropriate unlock
  * indicator. */
 unlock_state_t unlock_state;
-pam_state_t pam_state;
+auth_state_t auth_state;
 
 /*
  * Returns the scaling factor of the current screen. E.g., on a 227 DPI MacBook
@@ -141,7 +141,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
     }
 
     if (unlock_indicator &&
-        (unlock_state >= STATE_KEY_PRESSED || pam_state > STATE_PAM_IDLE)) {
+        (unlock_state >= STATE_KEY_PRESSED || auth_state > STATE_AUTH_IDLE)) {
         cairo_scale(ctx, scaling_factor(), scaling_factor());
         /* Draw a (centered) circle with transparent background. */
         cairo_set_line_width(ctx, 10.0);
@@ -154,12 +154,12 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
 
         /* Use the appropriate color for the different PAM states
          * (currently verifying, wrong password, or default) */
-        switch (pam_state) {
-            case STATE_PAM_VERIFY:
-            case STATE_PAM_LOCK:
+        switch (auth_state) {
+            case STATE_AUTH_VERIFY:
+            case STATE_AUTH_LOCK:
                 cairo_set_source_rgba(ctx, 0, 114.0 / 255, 255.0 / 255, 0.75);
                 break;
-            case STATE_PAM_WRONG:
+            case STATE_AUTH_WRONG:
             case STATE_I3LOCK_LOCK_FAILED:
                 cairo_set_source_rgba(ctx, 250.0 / 255, 0, 0, 0.75);
                 break;
@@ -169,16 +169,16 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         }
         cairo_fill_preserve(ctx);
 
-        switch (pam_state) {
-            case STATE_PAM_VERIFY:
-            case STATE_PAM_LOCK:
+        switch (auth_state) {
+            case STATE_AUTH_VERIFY:
+            case STATE_AUTH_LOCK:
                 cairo_set_source_rgb(ctx, 51.0 / 255, 0, 250.0 / 255);
                 break;
-            case STATE_PAM_WRONG:
+            case STATE_AUTH_WRONG:
             case STATE_I3LOCK_LOCK_FAILED:
                 cairo_set_source_rgb(ctx, 125.0 / 255, 51.0 / 255, 0);
                 break;
-            case STATE_PAM_IDLE:
+            case STATE_AUTH_IDLE:
                 cairo_set_source_rgb(ctx, 51.0 / 255, 125.0 / 255, 0);
                 break;
         }
@@ -205,14 +205,14 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         cairo_set_source_rgb(ctx, 0, 0, 0);
         cairo_select_font_face(ctx, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
         cairo_set_font_size(ctx, 28.0);
-        switch (pam_state) {
-            case STATE_PAM_VERIFY:
+        switch (auth_state) {
+            case STATE_AUTH_VERIFY:
                 text = "verifying…";
                 break;
-            case STATE_PAM_LOCK:
+            case STATE_AUTH_LOCK:
                 text = "locking…";
                 break;
-            case STATE_PAM_WRONG:
+            case STATE_AUTH_WRONG:
                 text = "wrong!";
                 break;
             case STATE_I3LOCK_LOCK_FAILED:
@@ -245,7 +245,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
             cairo_close_path(ctx);
         }
 
-        if (pam_state == STATE_PAM_WRONG && (modifier_string != NULL)) {
+        if (auth_state == STATE_AUTH_WRONG && (modifier_string != NULL)) {
             cairo_text_extents_t extents;
             double x, y;
 
@@ -334,7 +334,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
  *
  */
 void redraw_screen(void) {
-    DEBUG("redraw_screen(unlock_state = %d, pam_state = %d)\n", unlock_state, pam_state);
+    DEBUG("redraw_screen(unlock_state = %d, auth_state = %d)\n", unlock_state, auth_state);
     xcb_pixmap_t bg_pixmap = draw_image(last_resolution);
     xcb_change_window_attributes(conn, win, XCB_CW_BACK_PIXMAP, (uint32_t[1]){bg_pixmap});
     /* XXX: Possible optimization: Only update the area in the middle of the

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -11,12 +11,12 @@ typedef enum {
 } unlock_state_t;
 
 typedef enum {
-    STATE_PAM_IDLE = 0,          /* no PAM interaction at the moment */
-    STATE_PAM_VERIFY = 1,        /* currently verifying the password via PAM */
-    STATE_PAM_LOCK = 2,          /* currently locking the screen */
-    STATE_PAM_WRONG = 3,         /* the password was wrong */
+    STATE_AUTH_IDLE = 0,          /* no authenticator interaction at the moment */
+    STATE_AUTH_VERIFY = 1,        /* currently verifying the password via authenticator */
+    STATE_AUTH_LOCK = 2,          /* currently locking the screen */
+    STATE_AUTH_WRONG = 3,         /* the password was wrong */
     STATE_I3LOCK_LOCK_FAILED = 4 /* i3lock failed to load */
-} pam_state_t;
+} auth_state_t;
 
 xcb_pixmap_t draw_image(uint32_t* resolution);
 void redraw_screen(void);

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -11,10 +11,10 @@ typedef enum {
 } unlock_state_t;
 
 typedef enum {
-    STATE_AUTH_IDLE = 0,          /* no authenticator interaction at the moment */
-    STATE_AUTH_VERIFY = 1,        /* currently verifying the password via authenticator */
-    STATE_AUTH_LOCK = 2,          /* currently locking the screen */
-    STATE_AUTH_WRONG = 3,         /* the password was wrong */
+    STATE_AUTH_IDLE = 0,         /* no authenticator interaction at the moment */
+    STATE_AUTH_VERIFY = 1,       /* currently verifying the password via authenticator */
+    STATE_AUTH_LOCK = 2,         /* currently locking the screen */
+    STATE_AUTH_WRONG = 3,        /* the password was wrong */
     STATE_I3LOCK_LOCK_FAILED = 4 /* i3lock failed to load */
 } auth_state_t;
 

--- a/xcb.c
+++ b/xcb.c
@@ -24,7 +24,7 @@
 #include "cursors.h"
 #include "unlock_indicator.h"
 
-extern pam_state_t pam_state;
+extern auth_state_t auth_state;
 
 xcb_connection_t *conn;
 xcb_screen_t *screen;
@@ -262,7 +262,7 @@ void grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb
     /* After trying for 10000 times, i3lock will display an error message
      * for 2 sec prior to terminate. */
     if (tries <= 0) {
-        pam_state = STATE_I3LOCK_LOCK_FAILED;
+        auth_state = STATE_I3LOCK_LOCK_FAILED;
         redraw_screen();
         sleep(1);
         errx(EXIT_FAILURE, "Cannot grab pointer/keyboard");


### PR DESCRIPTION
This PR adds support for `bsd_auth(3)` as an authentication backend to i3lock. To keep things simple it's a compile-time option and enabled by default on OpenBSD-only.

In the process of keeping the actual addition of `bsd_auth(3)` as small as possible I renamed a lot of non-PAM specific variables/fields that had `PAM/pam` in them to `AUTH/auth`. I think this will also make it easier for future backends to be added.