### PR TITLE
Restore intended behaviour and don't use mlock(2) on OpenBSD.

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -919,12 +919,12 @@ int main(int argc, char *argv[]) {
         errx(EXIT_FAILURE, "PAM: %s", pam_strerror(pam_handle, ret));
 #endif
 
-/* Using mlock() as non-super-user seems only possible in Linux and OpenBSD.
+/* Using mlock() as non-super-user seems only possible in Linux.
  * Users of other operating systems should use encrypted swap/no swap
  * (or remove the ifdef and run i3lock as super-user).
- * NB: Alas, swap is encrypted by default on OpenBSD so swapping out
+ * Alas, swap is encrypted by default on OpenBSD so swapping out
  * is not necessarily an issue. */
-#if defined(__linux__) || defined(__OpenBSD__)
+#if defined(__linux__)
     /* Lock the area where we store the password in memory, we don’t want it to
      * be swapped to disk. Since Linux 2.6.9, this does not require any
      * privileges, just enough bytes in the RLIMIT_MEMLOCK limit. */


### PR DESCRIPTION
This addresses an issue that wasn't visible in my earlier testing due to the fact I had `i3lock` setuid root (to be able to call the bsdauth helpers), only to realize setgid auth suffices.

As a side note, i3lock is now packaged in [OpenBSD too](http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/x11/i3lock/Makefile).