### PR TITLE
Fix shadowing of getopt optind

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -819,7 +819,7 @@ int main(int argc, char *argv[]) {
 #endif
     int curs_choice = CURS_NONE;
     int o;
-    int optind = 0;
+    int longoptind = 0;
     struct option longopts[] = {
         {"version", no_argument, NULL, 'v'},
         {"nofork", no_argument, NULL, 'n'},
@@ -843,7 +843,7 @@ int main(int argc, char *argv[]) {
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
     char *optstring = "hvnbdc:p:ui:teI:f";
-    while ((o = getopt_long(argc, argv, optstring, longopts, &optind)) != -1) {
+    while ((o = getopt_long(argc, argv, optstring, longopts, &longoptind)) != -1) {
         switch (o) {
             case 'v':
                 errx(EXIT_SUCCESS, "version " VERSION " © 2010 Michael Stapelberg");
@@ -894,7 +894,7 @@ int main(int argc, char *argv[]) {
                 ignore_empty_password = true;
                 break;
             case 0:
-                if (strcmp(longopts[optind].name, "debug") == 0)
+                if (strcmp(longopts[longoptind].name, "debug") == 0)
                     debug_mode = true;
                 break;
             case 'f':


### PR DESCRIPTION
Hi,
a small dormant bug occurred to me while playing around with the getopt code:

The variable `optind` is used, probably out of habit, along the lines of [`getopt()`](https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html#index-optind). [`getopt_long()`](https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Options.html#index-getopt_005flong) however doesn't use `optind` as one of its parameters, but rather simply provides it. By using the name `optind` as the `indexptr` parameter it shadows the the actual optind and prevents any future option changes (such as my own hacking) from using it.

The effect can be seen with the following added line, before and after the changes from this PR:
```diff
diff --git a/i3lock.c b/i3lock.c
index e57eabc..bb1469f 100644
--- a/i3lock.c
+++ b/i3lock.c
@@ -855,6 +855,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'd':
                 fprintf(stderr, "DPMS support has been removed from i3lock. Please see the manpage i3lock(1).\n");
+                fprintf(stderr, "optind: %d\n", optind);
                 break;
             case 'I': {
                 fprintf(stderr, "Inactivity timeout only makes sense with DPMS, which was removed. Please see the manpage i3lock(1).\n");
```
and then running
`./i3lock -d`

On master this yields the line `optind: 0`, and after the PR this yields `optind: 2`.

`optind` is potentially useful for parsing multiple arguments to a parameter (I am currently hacking in multiple image support for myself).