### PR TITLE
Only use -lpam when not on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ CFLAGS += -Wall
 CPPFLAGS += -D_GNU_SOURCE
 CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
-LIBS += -lpam
 LIBS += -lev
 LIBS += -lm
 


### PR DESCRIPTION
There was a regression in 10416e27, the Makefile uses -lpam unconditionally. This causes the build to fail on OpenBSD. Deleting the line fixes it since -lpam is later added to LIBS if we're not on OpenBSD.