### PR TITLE
Change the locale discovery procedure to treat empty string same as unset

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -977,11 +977,11 @@ int main(int argc, char *argv[]) {
         errx(EXIT_FAILURE, "Could not load keymap");
 
     const char *locale = getenv("LC_ALL");
-    if (!locale)
+    if (!locale || !*locale)
         locale = getenv("LC_CTYPE");
-    if (!locale)
+    if (!locale || !*locale)
         locale = getenv("LANG");
-    if (!locale) {
+    if (!locale || !*locale) {
         if (debug_mode)
             fprintf(stderr, "Can't detect your locale, fallback to C\n");
         locale = "C";


### PR DESCRIPTION
This is explained in the commit message here:
https://github.com/xkbcommon/libxkbcommon/commit/f468f0b2430e15cc262c5745445580bd0dc64ef0