### PR TITLE
Immediately hide the unlock indicator after ESC / C-u

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -445,14 +445,9 @@ static void handle_key_press(xcb_key_press_event_t *event) {
                 ksym == XKB_KEY_Escape) {
                 DEBUG("C-u pressed\n");
                 clear_input();
-                /* Hide the unlock indicator after a bit if the password buffer is
-                 * empty. */
-                if (unlock_indicator) {
-                    START_TIMER(clear_indicator_timeout, 1.0, clear_indicator_cb);
-                    unlock_state = STATE_BACKSPACE_ACTIVE;
-                    redraw_screen();
-                    unlock_state = STATE_KEY_PRESSED;
-                }
+                /* Also hide the unlock indicator */
+                if (unlock_indicator)
+                    clear_indicator();
                 return;
             }
             break;


### PR DESCRIPTION
I think that this is better behavior because it visually resets i3lock to it's starting state: no key presses - no unlock indicator. It's also some visual feedback that your current password is deleted instead of mashing ESC 5 times.