### PR TITLE
SetInputFocus to the i3lock window to force-close context menus

### DIFF
--- a/xcb.h
+++ b/xcb.h
@@ -9,7 +9,9 @@ extern xcb_screen_t *screen;
 xcb_visualtype_t *get_root_visual_type(xcb_screen_t *s);
 xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, char *color);
 xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap);
-void grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor);
+bool grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor, int tries);
 xcb_cursor_t create_cursor(xcb_connection_t *conn, xcb_screen_t *screen, xcb_window_t win, int choice);
+xcb_window_t find_focused_window(xcb_connection_t *conn, const xcb_window_t root);
+void set_focused_window(xcb_connection_t *conn, const xcb_window_t root, const xcb_window_t window);
 
 #endif


### PR DESCRIPTION
When grabbing the pointer/keyboard fails, a new code path is activated, which:

1. Uses the standards-compliant _NET_ACTIVE_WINDOW root window property to
   determine the window to restore focus to.

2. Sets the input focus to the i3lock window, effectively force-closing any open
   context menus (tested with Google Chrome).

3. Upon exiting, restores focus to the window from step ① by sending a
   _NET_ACTIVE_WINDOW ClientMessage to the root window. Note that this step
   requires https://github.com/i3/i3/pull/3027 in i3 to not mess up focus.

fixes https://github.com/i3/i3lock/issues/35