### PR TITLE
Splitting image loading out of the main file, and adding JPEG support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     - libev-dev
     - libxcb-xinerama0-dev
     - libxcb-xkb-dev
+    - libjpeg-dev
 before_install:
   - "echo 'APT::Default-Release \"trusty\";' | sudo tee /etc/apt/apt.conf.d/default-release"
   - "echo 'deb http://archive.ubuntu.com/ubuntu/ xenial main universe' | sudo tee /etc/apt/sources.list.d/wily.list"

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,8 @@ i3lock_SOURCES = \
 	unlock_indicator.c \
 	unlock_indicator.h \
 	xcb.c \
-	xcb.h
+	xcb.h \
+	img_load.c
 
 EXTRA_DIST = \
 	$(pamd_files) \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Requirements
 - libx11-xcb-dev
 - libxkbcommon >= 0.5.0
 - libxkbcommon-x11 >= 0.5.0
+- libjpeg
 
 Running i3lock
 -------------

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,8 @@ AC_SEARCH_LIBS([pam_authenticate], [pam])
 
 AC_SEARCH_LIBS([iconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])])
 
+AC_SEARCH_LIBS([jpeg_std_error], [jpeg])
+
 dnl Each prefix corresponds to a source tarball which users might have
 dnl downloaded in a newer version and would like to overwrite.
 PKG_CHECK_MODULES([XCB], [xcb xcb-xkb xcb-xinerama xcb-randr])
@@ -87,6 +89,7 @@ PKG_CHECK_MODULES([XCB_IMAGE], [xcb-image])
 PKG_CHECK_MODULES([XCB_UTIL], [xcb-event xcb-util xcb-atom])
 PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon xkbcommon-x11])
 PKG_CHECK_MODULES([CAIRO], [cairo])
+PKG_CHECK_MODULES([LIBJPEG], [libjpeg])
 
 # Checks for programs.
 AC_PROG_AWK

--- a/i3lock.c
+++ b/i3lock.c
@@ -37,15 +37,15 @@
 #include <strings.h> /* explicit_bzero(3) */
 #endif
 #include <errno.h>
-#include <xcb/xcb_aux.h>
 #include <xcb/randr.h>
+#include <xcb/xcb_aux.h>
 
 #include "cursors.h"
 #include "i3lock.h"
 #include "img_load.h"
+#include "randr.h"
 #include "unlock_indicator.h"
 #include "xcb.h"
-#include "randr.h"
 
 #define TSTAMP_N_SECS(n) (n * 1.0)
 #define TSTAMP_N_MINS(n) (60 * TSTAMP_N_SECS(n))

--- a/i3lock.c
+++ b/i3lock.c
@@ -26,7 +26,6 @@
 #include <security/pam_appl.h>
 #endif
 #include <getopt.h>
-#include <string.h>
 #include <ev.h>
 #include <sys/mman.h>
 #include <xkbcommon/xkbcommon.h>
@@ -39,7 +38,9 @@
 #endif
 #include <xcb/xcb_aux.h>
 #include <xcb/randr.h>
+#include <errno.h>
 
+#include "img_load.h"
 #include "i3lock.h"
 #include "xcb.h"
 #include "cursors.h"
@@ -1009,12 +1010,15 @@ int main(int argc, char *argv[]) {
                                  (uint32_t[]){XCB_EVENT_MASK_STRUCTURE_NOTIFY});
 
     if (image_path) {
-        /* Create a pixmap to render on, fill it with the background color */
-        img = cairo_image_surface_create_from_png(image_path);
         /* In case loading failed, we just pretend no -i was specified. */
-        if (cairo_surface_status(img) != CAIRO_STATUS_SUCCESS) {
+        if (!cairo_image_surface_from_file(image_path, &img))
+        {
+            fprintf(stderr, "Could not load image \"%s\": %s\n", image_path, strerror(errno));
+            img = NULL;
+        } else if (cairo_surface_status(img) != CAIRO_STATUS_SUCCESS) {
             fprintf(stderr, "Could not load image \"%s\": %s\n",
                     image_path, cairo_status_to_string(cairo_surface_status(img)));
+            cairo_surface_destroy(img);
             img = NULL;
         }
         free(image_path);
@@ -1102,6 +1106,10 @@ int main(int argc, char *argv[]) {
     }
 
     DEBUG("restoring focus to X11 window 0x%08x\n", stolen_focus);
+    if (img != NULL)
+    {
+        cairo_surface_destroy(img);
+    }
     xcb_ungrab_pointer(conn, XCB_CURRENT_TIME);
     xcb_ungrab_keyboard(conn, XCB_CURRENT_TIME);
     xcb_destroy_window(conn, win);

--- a/i3lock.c
+++ b/i3lock.c
@@ -8,43 +8,43 @@
  */
 #include <config.h>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <assert.h>
+#include <err.h>
 #include <pwd.h>
-#include <sys/types.h>
-#include <string.h>
-#include <unistd.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <xcb/xcb.h>
 #include <xcb/xkb.h>
-#include <err.h>
-#include <assert.h>
 #ifdef __OpenBSD__
 #include <bsd_auth.h>
 #else
 #include <security/pam_appl.h>
 #endif
-#include <getopt.h>
-#include <ev.h>
-#include <sys/mman.h>
-#include <xkbcommon/xkbcommon.h>
-#include <xkbcommon/xkbcommon-compose.h>
-#include <xkbcommon/xkbcommon-x11.h>
 #include <cairo.h>
 #include <cairo/cairo-xcb.h>
+#include <ev.h>
+#include <getopt.h>
+#include <sys/mman.h>
+#include <xkbcommon/xkbcommon-compose.h>
+#include <xkbcommon/xkbcommon-x11.h>
+#include <xkbcommon/xkbcommon.h>
 #ifdef __OpenBSD__
 #include <strings.h> /* explicit_bzero(3) */
 #endif
+#include <errno.h>
 #include <xcb/xcb_aux.h>
 #include <xcb/randr.h>
-#include <errno.h>
 
-#include "img_load.h"
-#include "i3lock.h"
-#include "xcb.h"
 #include "cursors.h"
+#include "i3lock.h"
+#include "img_load.h"
 #include "unlock_indicator.h"
+#include "xcb.h"
 #include "randr.h"
 
 #define TSTAMP_N_SECS(n) (n * 1.0)
@@ -1011,8 +1011,7 @@ int main(int argc, char *argv[]) {
 
     if (image_path) {
         /* In case loading failed, we just pretend no -i was specified. */
-        if (!cairo_image_surface_from_file(image_path, &img))
-        {
+        if (!cairo_image_surface_from_file(image_path, &img)) {
             fprintf(stderr, "Could not load image \"%s\": %s\n", image_path, strerror(errno));
             img = NULL;
         } else if (cairo_surface_status(img) != CAIRO_STATUS_SUCCESS) {
@@ -1106,8 +1105,7 @@ int main(int argc, char *argv[]) {
     }
 
     DEBUG("restoring focus to X11 window 0x%08x\n", stolen_focus);
-    if (img != NULL)
-    {
+    if (img != NULL) {
         cairo_surface_destroy(img);
     }
     xcb_ungrab_pointer(conn, XCB_CURRENT_TIME);

--- a/img_load.c
+++ b/img_load.c
@@ -1,0 +1,386 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * © 2017 Rodrigo Toste Gomes
+ *
+ * See LICENSE for licensing information
+ *
+ */
+#include <assert.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <jpeglib.h>
+#include <setjmp.h>
+#include "img_load.h"
+
+#define CHECK(A) if (!(A)) return false
+
+typedef enum
+{
+    PNG,
+    JPEG,
+    NONE,
+    ERROR
+} supported_img_t;
+typedef int file_t;
+#define CHECKE(A) if (!(A)) return ERROR;
+
+#define CHECKEXIT(A) if(!(A)) goto exit
+
+#define CHECK_FILE_SIZE(fd, size) do                                    \
+{                                                                       \
+    off_t file_size = lseek(fd, 0, SEEK_END);                           \
+    CHECKE(file_size != -1);                                            \
+    assert(file_size > 0);                                              \
+    if ((size_t)file_size < size)                                       \
+    {                                                                   \
+        ret = NONE;                                                     \
+        goto exit;                                                      \
+    }                                                                   \
+} while(false);
+
+/*
+ * This function checks if the file passed in is a jpeg image. Meant to be used as a helper to
+ * `get_img_type`
+ *
+ * This function returns JPEG in case the image is a JPEG, otherwise returns NONE. If it returns
+ * ERROR, then the errno will be set. In case of error the file seek position may be arbitrary.
+ *
+ */
+#define MIN_JPEG_FILE_SIZE 4
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define JPEG_HEADER 0xD8FF
+#define JPEG_FOOTER 0xD9FF
+#else
+#define JPEG_HEADER 0xFFD8
+#define JPEG_FOOTER 0xFFD9
+#endif
+typedef uint16_t jpeg_header_t;
+typedef uint16_t jpeg_footer_t;
+static supported_img_t is_jpeg_img(const file_t img_file)
+{
+    supported_img_t ret = NONE;
+
+    off_t initial_offset = lseek(img_file, 0, SEEK_CUR);
+    /* `lseek` returns -1 in case of error, and sets errno */
+    CHECKE(initial_offset != -1);
+
+    /*
+     * Make sure file is large enough to contain a jpeg - need at least 4 bytes for header +
+     * footer
+     */
+    CHECK_FILE_SIZE(img_file, sizeof(jpeg_header_t) + sizeof(jpeg_footer_t));
+
+    /* check header */
+    jpeg_header_t header;
+    ssize_t bytes_read = pread(img_file, &header, sizeof(header), 0 /* offset */);
+    CHECKE(bytes_read != -1);
+    if (bytes_read != sizeof(header))
+    {
+        errno = EIO;
+        return ERROR;
+    }
+    if (header != JPEG_HEADER)
+    {
+        ret = NONE;
+        goto exit;
+    }
+
+    /* check footer */
+    CHECKE(lseek(img_file, -2, SEEK_END) != -1);
+    jpeg_footer_t footer;
+    bytes_read = read(img_file, &footer, sizeof(footer));
+    CHECKE(bytes_read != -1);
+    if (bytes_read != sizeof(footer))
+    {
+        errno = EIO;
+        return ERROR;
+    }
+    if (footer != JPEG_FOOTER)
+    {
+        ret = NONE;
+        goto exit;
+    }
+
+    ret = JPEG;
+  exit:
+    CHECKE(lseek(img_file, initial_offset, SEEK_SET) != -1);
+    return ret;
+}
+
+/*
+ * This function checks if the file passed in is a png image. Meant to be used as a helper to
+ * `get_img_type`
+ *
+ * This function returns PNG in case the image is a PNG, otherwise returns NONE. If it returns
+ * ERROR, then the errno will be set. In case of error the file seek position may be arbitrary.
+ *
+ */
+typedef uint64_t png_header_t;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define PNG_HEADER 0x0A1A0A0D474E5089
+#else
+#define PNG_HEADER 0x89504E470D0A1A0A
+#endif
+static supported_img_t is_png_img(const file_t img_file)
+{
+    supported_img_t ret = NONE;
+
+    off_t initial_offset = lseek(img_file, 0, SEEK_CUR);
+    /* `lseek` returns -1 in case of error, and sets errno */
+    CHECKE(initial_offset != -1);
+
+    CHECK_FILE_SIZE(img_file, sizeof(png_header_t));
+
+    /* check header */
+    png_header_t header;
+    ssize_t bytes_read = pread(img_file, &header, sizeof(header), 0 /* offset */);
+    CHECKE(bytes_read != -1);
+    if (bytes_read != sizeof(header))
+    {
+        errno = EIO;
+        return ERROR;
+    }
+    if (header != PNG_HEADER)
+    {
+        ret = NONE;
+        goto exit;
+    }
+
+    ret = PNG;
+  exit:
+    CHECKE(lseek(img_file, initial_offset, SEEK_SET) != -1);
+    return ret;
+}
+
+/*
+ * This function tries to determine the image type of the file whose open and valid file descriptor
+ * is passed in. Returns the value of `supported_img_t` that corresponds to that type, NONE if the
+ * file is not of a supported type, or ERROR if an error occurs (errno will be set).
+ *
+ * Note: in case of error the seek position in the file can be arbitrary. If all goes successfuly,
+ * though, the seek posiiton will be returned to its original value when this function was called.
+ *
+ */
+static supported_img_t get_img_type(FILE* const img_fp)
+{
+    assert(img_fp != NULL);
+    file_t img_file = fileno(img_fp);
+    assert(img_file >= 0);
+
+    supported_img_t ret = is_jpeg_img(img_file);
+    CHECKE(ret != ERROR);
+    CHECKEXIT(ret == NONE); /* fallthrough if NONE was returned */
+
+    ret = is_png_img(img_file);
+    CHECKE(ret != ERROR);
+    CHECKEXIT(ret == NONE); /* fallthrough if NONE was returned */
+
+  exit:
+    return ret;
+}
+
+/*
+ * Used to handle errors when decompressing jpeg - this error manager will cause execution to jump
+ * back to the owner of the error manager rather than failing the program. The caller will then
+ * handle the error in a non-fatal way.
+ *
+ */
+struct jmp_error_mgr
+{
+    struct jpeg_error_mgr mgr;
+    jmp_buf setjmp_buffer;
+};
+
+/*
+ * This function displays the error message, and then gives control back to the caller via longjmp.
+ *
+ */
+void jmp_error_exit (j_common_ptr cinfo)
+{
+    /* cinfo->err is a jmp_error_mgr object, even if it's stored as a different pointer type */
+    struct jmp_error_mgr* myerr = (struct jmp_error_mgr*) cinfo->err;
+    myerr->mgr.output_message(cinfo);
+    longjmp(myerr->setjmp_buffer, 1);
+}
+
+/*
+ * This function reads a jpeg image file, converts it into data that can be passed into
+ * `cairo_image_surface_create_for_data`, and loads it into a cairo surface object. Based on the
+ * following guide:
+ *
+ * https://www4.cs.fau.de/Services/Doc/graphics/doc/jpeg/libjpeg.html
+ *
+ * https://raw.githubusercontent.com/LuaDist/libjpeg/master/example.c
+ *
+ * It asumes that the passed in FILE object is valid.
+ *
+ * The resulting surface is stored in the output parameter `surface`. In case of errors, this
+ * function returns `false`, with errno set, otherwise it returns `true`.
+ *
+ */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define JPEG_COLOR_SPACE JCS_EXT_BGRA
+#else
+#define JPEG_COLOR_SPACE JCS_EXT_ARGB
+#endif
+static bool jpeg_to_cairo_surface(FILE* const img_file, cairo_surface_t** const surface)
+{
+    assert(img_file != NULL);
+    assert(fileno(img_file) != -1);
+
+    struct jpeg_decompress_struct cinfo;
+    struct jmp_error_mgr jerr;
+    JSAMPARRAY buffer = NULL;
+    unsigned char* data = NULL;
+
+    bool ret = false;
+    cinfo.err = jpeg_std_error(&jerr.mgr);
+    jerr.mgr.error_exit = jmp_error_exit;
+    if (setjmp(jerr.setjmp_buffer))
+    {
+        errno = EINVAL; /* catch-all error code, the actual error was printed by the mgr */
+        goto exit;
+    }
+
+    jpeg_create_decompress(&cinfo);
+    jpeg_stdio_src(&cinfo, img_file);
+
+    /*
+     * We can ignore the return value of `jpeg_read_header` since suspension is not possible on a
+     * stdio source, and we pass true to reject a tables-only JPEG file as an error.
+     *
+     * Similarly we ignore the return value of both `jpeg_start_decompress` and
+     * `jpeg_finish_decompress` as suspension is not possible.
+     *
+     */
+
+    (void) jpeg_read_header(&cinfo, TRUE);
+
+    /*
+     * Manipulate the output colorspace into one that cairo will work with. The most compatible
+     * format that I could find is jpeg's XBGR/RGBX -> cairo's RGB24.
+     *
+     */
+    cairo_format_t data_format;
+    cinfo.out_color_space = JPEG_COLOR_SPACE;
+    data_format = CAIRO_FORMAT_RGB24;
+
+    (void) jpeg_start_decompress(&cinfo);
+
+    JDIMENSION width = cinfo.output_width;
+    JDIMENSION height = cinfo.output_height;
+    int stride = cairo_format_stride_for_width(data_format, width);
+
+    /*
+     * Allocate a contiguous block of memory for data, since that's what cairo takes.
+     *
+     * libjpeg still needs a list of pointers, so we also allocate a list of pointers, and assign
+     * them to the correct places in the data array.
+     *
+     */
+    assert(sizeof(JSAMPLE) == 1);
+    data = malloc(stride * height);
+    CHECKEXIT(data != NULL);
+    buffer = malloc(height * sizeof(JSAMPROW));
+    CHECKEXIT(buffer != NULL);
+    for (size_t r = 0; r < height; ++r)
+    {
+        buffer[r] = &data[stride*r];
+    }
+
+    do
+    {
+        /*
+         * The number of scanlines read so far is kept in cinfo.output_scanline, so it is not
+         * necessary to store the output of jpeg_read_scanlines anywhere.
+         *
+         */
+        (void) jpeg_read_scanlines(
+            &cinfo,
+            buffer+cinfo.output_scanline,
+            height-cinfo.output_scanline);
+    } while(cinfo.output_scanline < height);
+
+    (void) jpeg_finish_decompress(&cinfo);
+
+    /*
+     * Now that we've filled the data from the jpeg file, create the cairo surface and make it own
+     * the data buffer. Note that after this the surface is going to be valid in some way, even if
+     * its status is failed. At that point the caller is responsible for checking the status of the
+     * surface for errors, and this function returns `true`.
+     *
+     */
+    ret = true;
+    *surface = cairo_image_surface_create_for_data(data, data_format, width, height, stride);
+    CHECKEXIT(cairo_surface_status(*surface) == CAIRO_STATUS_SUCCESS);
+    /* set jpeg mime data */
+    CHECKEXIT(cairo_surface_set_mime_data(
+                  *surface,
+                  CAIRO_MIME_TYPE_JPEG,
+                  data,
+                  height * stride,
+                  free,
+                  data) == CAIRO_STATUS_SUCCESS);
+    data = NULL;
+
+  exit:
+    jpeg_destroy_decompress(&cinfo);
+    if (data != NULL)
+    {
+        free(data);
+    }
+    if (buffer != NULL)
+    {
+        free(buffer);
+    }
+
+    return ret;
+}
+
+/*
+ * This function sets `*surface_out` to a valid pointer to a `cairo_surface_t` object set from the
+ * image file in `path`. It assumes `*surface_out` is NULL, otherwise we risk leaking memory.
+ *
+ * In case of an error prior to generating the cairo surface, this function returns `false`, errno
+ * will be set, and `*surface_out` will be unchanged. It is possible for the cairo code to hit an
+ * error generating the cairo surface. In that case this function still follows its contract - it
+ * sets `*surface_out` to a valid cairo surface, and it is the responsibility of the caller to check
+ * the status of that surface.
+ *
+ * All callers must check both the return value of this function (in case it is `false` more
+ * information exists in the errno) and the status of the cairo surface.
+ */
+bool cairo_image_surface_from_file(const char* path, cairo_surface_t** surface_out)
+{
+    assert(*surface_out == NULL);
+    FILE* img_file = fopen(path, "rb");
+    CHECK(img_file != NULL);
+
+    bool ret = true;
+    supported_img_t img_type = get_img_type(img_file);
+    switch (img_type)
+    {
+    case PNG:
+        /*
+         * We already have a file descriptor so this could be made a bit more efficient. It is,
+         * however, less risky and complex to just use cairo's builtin PNG extractor.
+         */
+        *surface_out = cairo_image_surface_create_from_png(path);
+        break;
+    case JPEG:
+        ret = jpeg_to_cairo_surface(img_file, surface_out);
+        break;
+    case NONE:
+        errno = EINVAL; /* path is an invalid argument - not a supported image type */
+        /* fallthrough */
+    case ERROR:
+        ret = false;
+    }
+
+    CHECK(fclose(img_file) == 0);
+    return ret;
+}

--- a/img_load.c
+++ b/img_load.c
@@ -360,7 +360,7 @@ bool cairo_image_surface_from_file(const char* path, cairo_surface_t** surface_o
             break;
         case NONE:
             errno = EINVAL; /* path is an invalid argument - not a supported image type */
-            /* fallthrough */
+                            /* fallthrough */
         case ERROR:
             ret = false;
     }

--- a/img_load.h
+++ b/img_load.h
@@ -1,8 +1,9 @@
 #ifndef _IMG_LOAD_H
 #define _IMG_LOAD_H
 
-#include <stdbool.h>
 #include <cairo/cairo.h>
+#include <stdbool.h>
+#include <stdio.h>
 
 bool cairo_image_surface_from_file(const char* path, cairo_surface_t** surface_out);
 

--- a/img_load.h
+++ b/img_load.h
@@ -1,0 +1,9 @@
+#ifndef _IMG_LOAD_H
+#define _IMG_LOAD_H
+
+#include <stdbool.h>
+#include <cairo/cairo.h>
+
+bool cairo_image_surface_from_file(const char* path, cairo_surface_t** surface_out);
+
+#endif


### PR DESCRIPTION
See #68 for discussion and context.

Also did some cleanup:
- Repeated string.h header include in i3lock.c;
- We were not destroying the cairo surface;

Also revamped error management during image loading. We won't get out of memory errors for
invalid types anymore. Fixes #114 

Finally, added libjpeg dependency.