### PR TITLE
display error when backspace is pressed without any input

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -472,8 +472,12 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             if (ksym == XKB_KEY_h && !ctrl)
                 break;
 
-            if (input_position == 0)
+            if (input_position == 0) {
+                START_TIMER(clear_indicator_timeout, 1.0, clear_indicator_cb);
+                unlock_state = STATE_NOTHING_TO_DELETE;
+                redraw_screen();
                 return;
+            }
 
             /* decrement input_position to point to the previous glyph */
             u8_dec(password, &input_position);

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -164,6 +164,10 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 cairo_set_source_rgba(ctx, 250.0 / 255, 0, 0, 0.75);
                 break;
             default:
+                if (unlock_state == STATE_NOTHING_TO_DELETE) {
+                    cairo_set_source_rgba(ctx, 250.0 / 255, 0, 0, 0.75);
+                    break;
+                }
                 cairo_set_source_rgba(ctx, 0, 0, 0, 0.75);
                 break;
         }
@@ -179,6 +183,11 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 cairo_set_source_rgb(ctx, 125.0 / 255, 51.0 / 255, 0);
                 break;
             case STATE_AUTH_IDLE:
+                if (unlock_state == STATE_NOTHING_TO_DELETE) {
+                    cairo_set_source_rgb(ctx, 125.0 / 255, 51.0 / 255, 0);
+                    break;
+                }
+
                 cairo_set_source_rgb(ctx, 51.0 / 255, 125.0 / 255, 0);
                 break;
         }
@@ -219,6 +228,9 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 text = "lock failed!";
                 break;
             default:
+                if (unlock_state == STATE_NOTHING_TO_DELETE) {
+                    text = "no input";
+                }
                 if (show_failed_attempts && failed_attempts > 0) {
                     if (failed_attempts > 999) {
                         text = "> 999";

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -2,20 +2,21 @@
 #define _UNLOCK_INDICATOR_H
 
 typedef enum {
-    STATE_STARTED = 0,         /* default state */
-    STATE_KEY_PRESSED = 1,     /* key was pressed, show unlock indicator */
-    STATE_KEY_ACTIVE = 2,      /* a key was pressed recently, highlight part
+    STATE_STARTED = 0,           /* default state */
+    STATE_KEY_PRESSED = 1,       /* key was pressed, show unlock indicator */
+    STATE_KEY_ACTIVE = 2,        /* a key was pressed recently, highlight part
                                    of the unlock indicator. */
-    STATE_BACKSPACE_ACTIVE = 3 /* backspace was pressed recently, highlight
+    STATE_BACKSPACE_ACTIVE = 3,  /* backspace was pressed recently, highlight
                                    part of the unlock indicator in red. */
+    STATE_NOTHING_TO_DELETE = 4, /* backspace was pressed, but there is nothing to delete. */
 } unlock_state_t;
 
 typedef enum {
-    STATE_AUTH_IDLE = 0,         /* no authenticator interaction at the moment */
-    STATE_AUTH_VERIFY = 1,       /* currently verifying the password via authenticator */
-    STATE_AUTH_LOCK = 2,         /* currently locking the screen */
-    STATE_AUTH_WRONG = 3,        /* the password was wrong */
-    STATE_I3LOCK_LOCK_FAILED = 4 /* i3lock failed to load */
+    STATE_AUTH_IDLE = 0,          /* no authenticator interaction at the moment */
+    STATE_AUTH_VERIFY = 1,        /* currently verifying the password via authenticator */
+    STATE_AUTH_LOCK = 2,          /* currently locking the screen */
+    STATE_AUTH_WRONG = 3,         /* the password was wrong */
+    STATE_I3LOCK_LOCK_FAILED = 4, /* i3lock failed to load */
 } auth_state_t;
 
 xcb_pixmap_t draw_image(uint32_t* resolution);


### PR DESCRIPTION
This adds some feedback to a keypress which previously had no visible effect.

While the text “no input” isn’t the most descriptive, it was the only one I
could think of which fit into the unlock indicator circle. If you have a better
suggestion, let me know.

fixes #164