### PR TITLE
return value corrected

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -807,8 +807,7 @@ static void raise_loop(xcb_window_t window) {
     xcb_generic_event_t *event;
     int screens;
 
-    if ((conn = xcb_connect(NULL, &screens)) == NULL ||
-        xcb_connection_has_error(conn))
+    if (xcb_connection_has_error((conn = xcb_connect(NULL, &screens))) > 0)
         errx(EXIT_FAILURE, "Cannot open display\n");
 
     /* We need to know about the window being obscured or getting destroyed. */


### PR DESCRIPTION
xcb_connect function never return NULL (see the man here : https://xcb.freedesktop.org/manual/group__XCB__Core__API.html#ga094470586356d1764e69c9a1882966c3)

"Callers need to use xcb_connection_has_error() to check for failure."

