### PR TITLE
 confusing error message getpwuid() 

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -807,8 +807,7 @@ static void raise_loop(xcb_window_t window) {
     xcb_generic_event_t *event;
     int screens;
 
-    if ((conn = xcb_connect(NULL, &screens)) == NULL ||
-        xcb_connection_has_error(conn))
+    if (xcb_connection_has_error((conn = xcb_connect(NULL, &screens))) > 0)
         errx(EXIT_FAILURE, "Cannot open display\n");
 
     /* We need to know about the window being obscured or getting destroyed. */

--- a/i3lock.c
+++ b/i3lock.c
@@ -879,8 +879,10 @@ int main(int argc, char *argv[]) {
         {"show-failed-attempts", no_argument, NULL, 'f'},
         {NULL, no_argument, NULL, 0}};
 
-    if ((pw = getpwuid(getuid())) == NULL)
+    if ((pw = getpwuid(getuid())) == NULL && errno != 0)
         err(EXIT_FAILURE, "getpwuid() failed");
+    else
+        errx(EXIT_FAILURE, "getpwuid() failed");
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 


### PR DESCRIPTION
In issue #175 the function getpwuid() sets errno to zero while it returns null.
I think that in this case it is not necessary to display errno because it is confusing.

