### PR TITLE
Added ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATION.
+-->
+
+## I'm submitting a…
+<!-- Please check one of the following options with "x" -->
+<pre>
+[ ] Bug
+[ ] Feature Request
+[ ] Other (Please describe in detail)
+</pre>
+
+## Current Behavior
+<!-- Describe the current behavior -->
+
+## Expected Behavior
+<!-- Describe the desired behavior you expect after mitigation of the issue -->
+
+## Reproduction Instructions
+<!--
+For bug reports, please provide detailed instructions on how the bug can be reproduced.
+For feature requests, you can remove this section.
+-->
+
+## Environment
+Output of `i3lock --version`:
+<pre>
+i3lock version: 
+</pre>


### PR DESCRIPTION
This adds an issue template for i3lock. The content of the template is inspired by angular/angular. I'd like to update the template in i3 in a similar fashion, perhaps we could also update the bot to use the checkboxes to deal with tags more easily (it's currently not transparent to users how to open issues which should be tagged as feature requests) and close questions that are missing version information.