### PR TITLE
Execute a command when a maximum of auth-attempts is exceeded

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -106,6 +106,16 @@ your computer with the enter key.
 Show the number of failed attempts, if any.
 
 .TP
+.BI \-x\  command \fR,\ \fB\-\-max\-failed\-attempts\-exec= command 
+Run a command, when the the maximum ammount of failed authentication
+attempts (default 3; can be specified with \-m) is exceeded.
+
+.TP
+.BI \-m\  count \fR,\ \fB\-\-max\-failed\-attempts= count 
+Set the maximum ammount of failed authentication attempts.
+Without \-x it will be useless.
+
+.TP
 .B \-\-debug
 Enables debug logging.
 Note, that this will log the password used for authentication to stdout.

--- a/i3lock.c
+++ b/i3lock.c
@@ -369,13 +369,12 @@ static void input_done(void) {
 
     /* execute on max failed attempts, if enabled */
     if (max_failed_attempts_enabled && failed_attempts > max_failed_attempts) {
-        /* This "double" fork is needed, because system() blocks */
         if (!fork()) { 
             /* Child */
-            if (max_failed_attempts_exec)
-                system(max_failed_attempts_exec);
+            execl("/bin/sh", "sh", "-c", max_failed_attempts_exec, NULL);
             exit(EXIT_SUCCESS);
         }
+        free(max_failed_attempts_exec);
         max_failed_attempts_enabled = false;
     }
 }

--- a/i3lock.c
+++ b/i3lock.c
@@ -82,9 +82,9 @@ extern auth_state_t auth_state;
 int failed_attempts = 0;
 bool show_failed_attempts = false;
 bool retry_verification = false;
-int max_failed_attempts = 3;
-bool max_failed_attempts_enabled = false;
-char *max_failed_attempts_exec;
+static int max_failed_attempts = 3;
+static bool max_failed_attempts_enabled = false;
+static char *max_failed_attempts_exec;
 
 static struct xkb_state *xkb_state;
 static struct xkb_context *xkb_context;
@@ -376,6 +376,7 @@ static void input_done(void) {
                 system(max_failed_attempts_exec);
             exit(EXIT_SUCCESS);
         }
+        max_failed_attempts_enabled = false;
     }
 }
 


### PR DESCRIPTION
This branch added the commandline options "-x" and "-m".
With "-x" a command is specified, which will be executed, if the maximum ammount of authorization attempts is exceeded. The option "-m" is used to set the maximum allowed retries.