### PR TITLE
Add command line options for hiding text and changing the color of the unlock indicator

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -59,6 +59,7 @@ typedef void (*ev_callback_t)(EV_P_ ev_timer *w, int revents);
 static void input_done(void);
 
 char color[7] = "ffffff";
+char ring_color[7] = "337d00";
 uint32_t last_resolution[2];
 xcb_window_t win;
 static xcb_cursor_t cursor;
@@ -875,6 +876,7 @@ int main(int argc, char *argv[]) {
         {"help", no_argument, NULL, 'h'},
         {"no-unlock-indicator", no_argument, NULL, 'u'},
         {"no-text", no_argument, NULL, 's'},
+        {"ring_color", required_argument, NULL, 'r'},
         {"image", required_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
@@ -887,7 +889,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:fs";
+    char *optstring = "hvnbdc:p:ui:teI:fsr:";
     while ((o = getopt_long(argc, argv, optstring, longopts, &longoptind)) != -1) {
         switch (o) {
             case 'v':
@@ -913,6 +915,17 @@ int main(int argc, char *argv[]) {
                     arg++;
 
                 if (strlen(arg) != 6 || sscanf(arg, "%06[0-9a-fA-F]", color) != 1)
+                    errx(EXIT_FAILURE, "color is invalid, it must be given in 3-byte hexadecimal format: rrggbb\n");
+
+                break;
+            }
+            case 'r': {
+                char *arg = optarg;
+
+                if (arg[0] == '#')
+                    arg++;
+
+                if (strlen(arg) != 6 || sscanf(arg, "%06[0-9a-fA-F]", ring_color) != 1)
                     errx(EXIT_FAILURE, "color is invalid, it must be given in 3-byte hexadecimal format: rrggbb\n");
 
                 break;
@@ -950,7 +963,7 @@ int main(int argc, char *argv[]) {
                 break;
             default:
                 errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-s] [-p win|default]"
-                                   " [-i image.png] [-t] [-e] [-I timeout] [-f]");
+                                   " [-r color] [-i image.png] [-t] [-e] [-I timeout] [-f]");
         }
     }
 
@@ -1036,6 +1049,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_compose_table(locale);
+
+    init_colors();
 
     screen = xcb_setup_roots_iterator(xcb_get_setup(conn)).data;
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -71,6 +71,7 @@ static char password[512];
 static bool beep = false;
 bool debug_mode = false;
 bool unlock_indicator = true;
+bool write_text = true;
 char *modifier_string = NULL;
 static bool dont_fork = false;
 struct ev_loop *main_loop;
@@ -873,6 +874,7 @@ int main(int argc, char *argv[]) {
         {"debug", no_argument, NULL, 0},
         {"help", no_argument, NULL, 'h'},
         {"no-unlock-indicator", no_argument, NULL, 'u'},
+        {"no-text", no_argument, NULL, 's'},
         {"image", required_argument, NULL, 'i'},
         {"tiling", no_argument, NULL, 't'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
@@ -885,7 +887,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.\n");
 
-    char *optstring = "hvnbdc:p:ui:teI:f";
+    char *optstring = "hvnbdc:p:ui:teI:fs";
     while ((o = getopt_long(argc, argv, optstring, longopts, &longoptind)) != -1) {
         switch (o) {
             case 'v':
@@ -918,6 +920,9 @@ int main(int argc, char *argv[]) {
             case 'u':
                 unlock_indicator = false;
                 break;
+            case 's':
+                write_text = false;
+                break;
             case 'i':
                 image_path = strdup(optarg);
                 break;
@@ -944,7 +949,7 @@ int main(int argc, char *argv[]) {
                 show_failed_attempts = true;
                 break;
             default:
-                errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
+                errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-s] [-p win|default]"
                                    " [-i image.png] [-t] [-e] [-I timeout] [-f]");
         }
     }

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -56,6 +56,8 @@ extern cairo_surface_t *img;
 extern bool tile;
 /* The background color to use (in hex). */
 extern char color[7];
+/* Whether to write text on the unlock indicator. */
+extern bool write_text;
 
 /* Whether the failed attempts should be displayed. */
 extern bool show_failed_attempts;
@@ -235,7 +237,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 break;
         }
 
-        if (text) {
+        if (text && write_text) {
             cairo_text_extents_t extents;
             double x, y;
 

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -19,6 +19,7 @@ typedef enum {
     STATE_I3LOCK_LOCK_FAILED = 4, /* i3lock failed to load */
 } auth_state_t;
 
+void init_colors(void);
 xcb_pixmap_t draw_image(uint32_t* resolution);
 void redraw_screen(void);
 void clear_indicator(void);


### PR DESCRIPTION
- Added a command line option to hide the status messages like 'verifying...' and 'wrong!'
- Added a command line option to change the color of the unlock indicator ring, the default being the previous color. The color of the arcs highlighted for key presses is calculated automatically as a desaturated and lighter version of the given ring color, in a way that agrees with the original hardcoded highlight color.