### PR TITLE
Rename Win Key to Super Key

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -336,7 +336,7 @@ static void input_done(void) {
         else if (strcmp(mod_name, XKB_MOD_NAME_NUM) == 0)
             mod_name = "Num Lock";
         else if (strcmp(mod_name, XKB_MOD_NAME_LOGO) == 0)
-            mod_name = "Win";
+            mod_name = "Super";
 
         char *tmp;
         if (modifier_string == NULL) {


### PR DESCRIPTION
In most Linux environments, this key is referred to as "Super" to prevent infringing Microsoft's trademarks. Whilst "Win" is not a trademark of Microsoft it would be nice to be consistent.

https://en.wikipedia.org/wiki/Super_key_(keyboard_button) 