### PR TITLE
Added hook when login failed/succeed.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2018-10-18 i3lock 2.12
+
+ • Add hooks when login failed/succeed
+
 2018-10-18 i3lock 2.11.1
 
  • Fix dist tarball by including I3LOCK_VERSION


### PR DESCRIPTION
*This is a PR by https://mastodon.xyz/@Darks who does not have a GitHub account.*

Exemples:
* Take a picture with webcam when login failed
* Send a notification if someone tried to login

Environnement variable I3L_ATTEMPTS can be used in the hook scripts.
Ex: `notifify-send -u critical "$I3L_ATTEMPTS failed login attempts"`