### PR TITLE
add ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Many little improvements have been made to i3lock over time:
 - i3lock uses PAM and therefore is compatible with LDAP etc.
   On OpenBSD i3lock uses the bsd_auth(3) framework.
 
-Running i3lock
--------------
+Install
+-------
 Ubuntu:
 ```
 sudo apt-get install i3lock

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 i3lock - improved screen locker
 ===============================
-i3lock is a simple screen locker like slock. After starting it, you will
-see a white screen (you can configure the color/an image). You can return
-to your screen by entering your password.
+[i3lock](https://i3wm.org/i3lock/)> is a simple screen locker like slock.
+After starting it, you will see a white screen (you can configure the
+color/an image). You can return to your screen by entering your password.
 
 Many little improvements have been made to i3lock over time:
 
@@ -20,12 +20,8 @@ Many little improvements have been made to i3lock over time:
 
 Install
 -------
-Ubuntu:
-```
-sudo apt-get install i3lock
-```
 
-For other operating systems, see Requirements and Building below.
+See [the i3lock home page](https://i3wm.org/i3lock/).
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Many little improvements have been made to i3lock over time:
 - i3lock uses PAM and therefore is compatible with LDAP etc.
   On OpenBSD i3lock uses the bsd_auth(3) framework.
 
+Running i3lock
+-------------
+Ubuntu:
+```
+sudo apt-get install i3lock
+```
+
+For other operating systems, see Requirements and Building below.
+
 Requirements
 ------------
 - pkg-config


### PR DESCRIPTION
This would have saved me (and presumably some others) several hours.

The Github page is the second Google result for "i3lock", so users are likely to end up here. Makes sense to put user-facing install instructions up front.