### PR TITLE
Add an option to read an image as raw bytes rather than PNG

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -20,6 +20,8 @@ i3lock \- improved screen locker
 .RB [\|\-b\|]
 .RB [\|\-i
 .IR image.png \|]
+.RB [\|\-r
+.IR format \|]
 .RB [\|\-c
 .IR color \|]
 .RB [\|\-t\|]
@@ -73,6 +75,16 @@ verified or whether it is wrong).
 .TP
 .BI \-i\  path \fR,\ \fB\-\-image= path
 Display the given PNG image instead of a blank screen.
+
+.TP
+.BI \-r\  format \fR,\ \fB\-\-raw= format
+Read the image given by \-\-image as a raw image instead of PNG. The argument is the image's format
+as <width>x<height>:<pixfmt>. The supported pixel formats are 'native' and 'rgb'.
+The "rgb" pixel format expects a pixel to be three bytes; red, green, and blue.
+The "native" pixel format expects a pixel as a 32-bit (4-byte) integer in
+the machine's native endianness, with the upper 8 bits unused. Red, green and blue are stored in
+the remaining bits, in that order.
+Example: \-\-raw=1920x1080:rgb
 
 .TP
 .BI \-c\  rrggbb \fR,\ \fB\-\-color= rrggbb


### PR DESCRIPTION
There's a lot of tools, such as [i3lock-fancy-rapid](https://github.com/yvbbrjdr/i3lock-fancy-rapid), which work by creating an image, encoding that image as PNG, and running `i3lock -i <path>`. I tried using that i3lock-fancy-rapid on my machine, which has a 4k display, and found that just encoding the PNG image and writing it to a file took seconds; longer than the actual blur in some cases.

This patch makes it possible to just dump a buffer of raw pixel bytes into i3lock. I made my own [fork of i3lock-fancy-rapid](https://github.com/mortie/i3lock-fancy-rapid/blob/b398782186bf6b2f9db4e276860de27a58c7e5d7/i3lock-fancy-rapid.c#L145-L163), and found that with my preferred level of blurring, it's twice as fast; going from 0.68 seconds to 0.33 seconds. Without the blur, the difference is even bigger; from 0.65 seconds to 0.2 seconds.

I completely understand if this is out of scope for i3lock or something, I'll just keep maintaining my own branch, but I really think the performance gains are worth it. It also fits the "you should do all pre-processing in external tools" idea.