### PR TITLE
Remove one last reference to the -r shortopt

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -20,8 +20,6 @@ i3lock \- improved screen locker
 .RB [\|\-b\|]
 .RB [\|\-i
 .IR image.png \|]
-.RB [\|\-r
-.IR format \|]
 .RB [\|\-c
 .IR color \|]
 .RB [\|\-t\|]


### PR DESCRIPTION
I'm sorry I missed this earlier. I just noticed it now while reading through a diff.