### PR TITLE
Revert "Add option to lock TTY switching"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,3 @@ EXTRA_DIST = \
 	LICENSE \
 	README.md \
 	I3LOCK_VERSION
-
-# SUID the executable so it has permissions to lock TTY switching
-install-exec-hook:
-	chmod +s $(DESTDIR)$(bindir)/i3lock$(EXEEXT)

--- a/i3lock.1
+++ b/i3lock.1
@@ -28,7 +28,6 @@ i3lock \- improved screen locker
 .RB [\|\-u\|]
 .RB [\|\-e\|]
 .RB [\|\-f\|]
-.RB [\|\-l\|]
 
 .SH DESCRIPTION
 .B i3lock
@@ -115,10 +114,6 @@ your computer with the enter key.
 .TP
 .B \-f, \-\-show-failed-attempts
 Show the number of failed attempts, if any.
-
-.TP
-.B \-l, \-\-lock-console
-Lock the console to disable TTY switching (Linux only).
 
 .TP
 .B \-\-debug

--- a/i3lock.c
+++ b/i3lock.c
@@ -40,11 +40,6 @@
 #endif
 #include <xcb/xcb_aux.h>
 #include <xcb/randr.h>
-#if defined(__linux__)
-#include <fcntl.h>
-#include <linux/vt.h>
-#include <sys/ioctl.h>
-#endif
 
 #include "i3lock.h"
 #include "xcb.h"
@@ -1018,11 +1013,6 @@ int main(int argc, char *argv[]) {
     int ret;
     struct pam_conv conv = {conv_callback, NULL};
 #endif
-#if defined(__linux__)
-    bool lock_tty_switching = false;
-    int term = -1;
-#endif
-
     int curs_choice = CURS_NONE;
     int o;
     int longoptind = 0;
@@ -1042,7 +1032,6 @@ int main(int argc, char *argv[]) {
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
-        {"lock-console", no_argument, NULL, 'l'},
         {NULL, no_argument, NULL, 0}};
 
     if ((pw = getpwuid(getuid())) == NULL)
@@ -1050,7 +1039,7 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL)
         errx(EXIT_FAILURE, "pw->pw_name is NULL.");
 
-    char *optstring = "hvnbdc:p:ui:teI:fl";
+    char *optstring = "hvnbdc:p:ui:teI:f";
     while ((o = getopt_long(argc, argv, optstring, longopts, &longoptind)) != -1) {
         switch (o) {
             case 'v':
@@ -1110,16 +1099,9 @@ int main(int argc, char *argv[]) {
             case 'f':
                 show_failed_attempts = true;
                 break;
-            case 'l':
-#if defined(__linux__)
-                lock_tty_switching = true;
-#else
-                errx(EXIT_FAILURE, "TTY switch locking is only supported on Linux.");
-#endif
-                break;
             default:
                 errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
-                                   " [-i image.png] [-t] [-e] [-I timeout] [-f] [-l]");
+                                   " [-i image.png] [-t] [-e] [-I timeout] [-f]");
         }
     }
 
@@ -1291,21 +1273,6 @@ int main(int argc, char *argv[]) {
     if (main_loop == NULL)
         errx(EXIT_FAILURE, "Could not initialize libev. Bad LIBEV_FLAGS?");
 
-#if defined(__linux__)
-
-    /* Lock tty switching */
-    if (lock_tty_switching) {
-        if ((term = open("/dev/console", O_RDWR)) == -1) {
-            perror("error locking TTY switching: opening console failed");
-        }
-
-        if (term != -1 && (ioctl(term, VT_LOCKSWITCH)) == -1) {
-            perror("error locking TTY switching: locking console failed");
-        }
-    }
-
-#endif
-
     /* Explicitly call the screen redraw in case "locking…" message was displayed */
     auth_state = STATE_AUTH_IDLE;
     redraw_screen();
@@ -1332,18 +1299,6 @@ int main(int argc, char *argv[]) {
     if (stolen_focus == XCB_NONE) {
         return 0;
     }
-
-#if defined(__linux__)
-    /* Restore tty switching */
-    if (lock_tty_switching) {
-        if (term != -1 && (ioctl(term, VT_UNLOCKSWITCH)) == -1) {
-            perror("error unlocking TTY switching: unlocking console failed");
-        }
-
-        close(term);
-    }
-
-#endif
 
     DEBUG("restoring focus to X11 window 0x%08x\n", stolen_focus);
     xcb_ungrab_pointer(conn, XCB_CURRENT_TIME);


### PR DESCRIPTION
This reverts commit dcfcba3ed48587f607dd37f08dcf55b731dc2303.

As-is, this requires i3lock to be run with too many permissions, for a feature
which many users will never need. In issue #231, we concluded that interested
users are better off using a dedicated virtual console locker such as vlock(1).

related to #231