### PR TITLE
unlock_indicator.c: fix build failure against gcc-10

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -35,7 +35,7 @@ extern bool debug_mode;
 
 /* The current position in the input buffer. Useful to determine if any
  * characters of the password have already been entered or not. */
-int input_position;
+extern int input_position;
 
 /* The lock window. */
 extern xcb_window_t win;


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
  CCLD     i3lock
ld: i3lock-unlock_indicator.o:i3lock/unlock_indicator.c:38:
  multiple definition of `input_position'; i3lock-i3lock.o:i3lock/i3lock.c:69: first defined here
ld: i3lock-unlock_indicator.o:(.bss+0x102): multiple definition of `__odr_asan.input_position'; i3lock-i3lock.o:(.bss+0x92b): first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Hans de Graaff
Bug: https://bugs.gentoo.org/706286