### PR TITLE
Add option to remove text indicators

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -26,6 +26,7 @@ i3lock \- improved screen locker
 .RB [\|\-p
 .IR pointer\|]
 .RB [\|\-u\|]
+.RB [\|\-r\|]
 .RB [\|\-e\|]
 .RB [\|\-f\|]
 
@@ -66,6 +67,13 @@ like when opening your laptop in a boring lecture.
 .B \-u, \-\-no-unlock-indicator
 Disable the unlock indicator. i3lock will by default show an unlock indicator
 after pressing keys. This will give feedback for every keypress and it will
+show you the current PAM state (whether your password is currently being
+verified or whether it is wrong).
+
+.TP
+.B \-r, \-\-remove-text-indicator
+Disable the text indicator. i3lock will by default display text to indicate the
+state of the lock. This will give feedback when locking or unlocking and it will
 show you the current PAM state (whether your password is currently being
 verified or whether it is wrong).
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -72,6 +72,7 @@ static char password[512];
 static bool beep = false;
 bool debug_mode = false;
 bool unlock_indicator = true;
+bool text_indicator = true;
 char *modifier_string = NULL;
 static bool dont_fork = false;
 struct ev_loop *main_loop;
@@ -1027,6 +1028,7 @@ int main(int argc, char *argv[]) {
         {"debug", no_argument, NULL, 0},
         {"help", no_argument, NULL, 'h'},
         {"no-unlock-indicator", no_argument, NULL, 'u'},
+        {"remove-text-indicator", no_argument, NULL, 'r'},
         {"image", required_argument, NULL, 'i'},
         {"raw", required_argument, NULL, 0},
         {"tiling", no_argument, NULL, 't'},
@@ -1072,6 +1074,9 @@ int main(int argc, char *argv[]) {
             }
             case 'u':
                 unlock_indicator = false;
+                break;
+            case 'r':
+                text_indicator = false;
                 break;
             case 'i':
                 image_path = strdup(optarg);

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -46,6 +46,9 @@ extern uint32_t last_resolution[2];
 /* Whether the unlock indicator is enabled (defaults to true). */
 extern bool unlock_indicator;
 
+/* Whether the text indicator is enabled (defaults to true). */
+extern bool text_indicator;
+
 /* List of pressed modifiers, or NULL if none are pressed. */
 extern char *modifier_string;
 
@@ -235,7 +238,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                 break;
         }
 
-        if (text) {
+        if (text && text_indicator) {
             cairo_text_extents_t extents;
             double x, y;
 


### PR DESCRIPTION
Add an additional option -r/--remove-text-indicator to disable
the text indicator when locking or unlocking.
i.e. when it says "Verifying..." or "Wrong!".

This is an option for a minor aesthetic change, but I've made
multiple tweaks such as this in order to customize my desktop
experience and I wonder if others might find this useful too.