### PR TITLE
add extension support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,8 @@ AC_SEARCH_LIBS([floor], [m], , [AC_MSG_FAILURE([cannot find the required floor()
 # libev does not ship with a pkg-config file :(.
 AC_SEARCH_LIBS([ev_run], [ev], , [AC_MSG_FAILURE([cannot find the required ev_run() function despite trying to link with -lev])])
 
+AC_SEARCH_LIBS([dlopen], [dl])
+
 AC_SEARCH_LIBS([shm_open], [rt])
 
 # Only disable PAM on OpenBSD where i3lock uses BSD Auth instead

--- a/i3lock_ext.h
+++ b/i3lock_ext.h
@@ -1,0 +1,13 @@
+#ifndef _I3LOCK_EXT_H
+#define _I3LOCK_EXT_H
+
+struct i3lock_extapi {
+    void (*redraw)(void);
+};
+
+struct i3lock_ext {
+    void (*init)(const struct i3lock_extapi *api);
+    void (*draw_bg)(cairo_t *cr);
+};
+
+#endif

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -21,6 +21,7 @@
 #include "unlock_indicator.h"
 #include "randr.h"
 #include "dpi.h"
+#include "i3lock_ext.h"
 
 #define BUTTON_RADIUS 90
 #define BUTTON_SPACE (BUTTON_RADIUS + 5)
@@ -61,6 +62,8 @@ extern char color[7];
 extern bool show_failed_attempts;
 /* Number of failed unlock attempts. */
 extern int failed_attempts;
+
+extern struct i3lock_ext *ext;
 
 /*******************************************************************************
  * Variables defined in xcb.c.
@@ -129,6 +132,10 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         cairo_set_source_rgb(xcb_ctx, rgb16[0] / 255.0, rgb16[1] / 255.0, rgb16[2] / 255.0);
         cairo_rectangle(xcb_ctx, 0, 0, resolution[0], resolution[1]);
         cairo_fill(xcb_ctx);
+    }
+
+    if (ext && ext->draw_bg) {
+        ext->draw_bg(xcb_ctx);
     }
 
     if (unlock_indicator &&


### PR DESCRIPTION
This is just a proof of concept to start the conversation about weather you want this or not.
This is a small change to allow people to draw their own background using cairo while keeping their code out of i3lock. The code is loaded via libdl.

The extensions can even add their own callbacks(like timers) to the event loop without any additional i3lock logic because i3lock uses `EV_DEFAULT` anyway.

This would allow implementing things like #7 or #47 without touching i3locks code.