### PR TITLE
avoid pixmap allocations in the redraw path

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -1221,7 +1221,8 @@ int main(int argc, char *argv[]) {
     free(image_raw_format);
 
     /* Pixmap on which the image is rendered to (if any) */
-    xcb_pixmap_t bg_pixmap = draw_image(last_resolution);
+    xcb_pixmap_t bg_pixmap = create_bg_pixmap(conn, screen, last_resolution, color);
+    draw_image(bg_pixmap, last_resolution);
 
     xcb_window_t stolen_focus = find_focused_window(conn, screen->root);
 

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -1,6 +1,8 @@
 #ifndef _UNLOCK_INDICATOR_H
 #define _UNLOCK_INDICATOR_H
 
+#include <xcb/xcb.h>
+
 typedef enum {
     STATE_STARTED = 0,           /* default state */
     STATE_KEY_PRESSED = 1,       /* key was pressed, show unlock indicator */
@@ -19,7 +21,8 @@ typedef enum {
     STATE_I3LOCK_LOCK_FAILED = 4, /* i3lock failed to load */
 } auth_state_t;
 
-xcb_pixmap_t draw_image(uint32_t* resolution);
+void free_bg_pixmap(void);
+void draw_image(xcb_pixmap_t bg_pixmap, uint32_t* resolution);
 void redraw_screen(void);
 void clear_indicator(void);
 


### PR DESCRIPTION
Before this change, i3lock could become unusable on systems where pixmap
allocations take long.

I don’t know precisely why, but slow pixmap allocations is a symptom that my
computer sometimes exhibits, apparently when low on GPU memory.

In that situation, duplicate key press events would be processed (apparently
received from X11!), making correct password entry impossible.