### PR TITLE
Support changing colors and font through the X resource database system

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -137,6 +137,76 @@ Show the number of failed attempts, if any.
 Enables debug logging.
 Note, that this will log the password used for authentication to stdout.
 
+.SH STYLING
+
+Basic styling of colors and fonts is available through the X resource database system,
+for example by specifying them in the $HOME/.Xresources file.
+
+Most available options are of the format
+
+.RS
+i3lock.Lockscreen.\fBCOMPONENT\fR.\fBSTATE\fR.color:\ \fI#rrggbbaa\fR
+.RE
+
+where \fBCOMPONENT\fR may be one of
+
+.RS
+.TS
+tab (@);
+l l.
+ring@the indicator ring
+interior@the interior of the ring
+border@the border separating the ring, interior and keypress-indicator
+font@the font
+.TE
+.RE
+
+and \fBSTATE\fR may be one of
+
+.RS
+.TS
+tab (@);
+l l.
+normal@default state
+verify@on verification
+fail@on failure/locking
+.TE
+.RE
+
+The leading '#' and the alpha value of the color are optional.
+Other formats, such as named colors, are not supported.
+
+Additionally, the following options are available:
+
+.TP
+.BI i3lock.Lockscreen.background.color: \ #rrggbb
+Sets the background color. The command-line option \-c (\-\-color) will override this setting.
+A alpha value will be ignored on this option for security reasons.
+
+.TP
+.BI i3lock.Lockscreen.font.attempts.color: \ #rrggbbaa
+Sets the font color for the text showing the number of failed attempts (\-f, \-\-show-failed-attempts).
+
+.TP
+.BI i3lock.Lockscreen.keypress.color: \ #rrggbbaa
+Sets the color of the indicator shown when a key is pressed.
+
+.TP
+.BI i3lock.Lockscreen.backspace.color: \ #rrggbbaa
+Sets the color of the indicator shown when backspace is pressed.
+
+.TP
+.BI i3lock.Lockscreen.font:\ \fI\-*\-family\-weight\-slant\-*\-*\-pixelsize\-\fR
+Sets the font using the XLFD format. Supports a shortend form where later parts
+of the format may be ommited entirely (as in the example above). Other font
+options than those given in the example above are ignored.
+.br
+For \fIweight\fR only the options "medium" and "bold" are supported.
+.br
+For \fIslant\fR only 'r' (roman, ie. regular/upright), 's' (slanted) and 'o' (oblique) are supported.
+.br
+For \fIpixelsize\fR only the pixel size form is supported, the matrix form is not supported. This value is used as base font size, additional font sizes are calculated from it.
+
 .SH DPMS
 
 The \-d (\-\-dpms) option was removed from i3lock in version 2.8. There were

--- a/i3lock.h
+++ b/i3lock.h
@@ -1,6 +1,8 @@
 #ifndef _I3LOCK_H
 #define _I3LOCK_H
 
+#include <stdint.h>
+
 /* This macro will only print debug output when started with --debug.
  * This is important because xautolock (for example) closes stdout/stderr by
  * default, so just printing something to stdout will lead to the data ending
@@ -11,5 +13,12 @@
             fprintf(stderr, "[i3lock-debug] " fmt, ##__VA_ARGS__); \
         }                                                          \
     } while (0)
+
+typedef struct {
+    uint8_t red;
+    uint8_t green;
+    uint8_t blue;
+    float alpha;
+} rgba_t;
 
 #endif

--- a/xcb.c
+++ b/xcb.c
@@ -23,6 +23,7 @@
 
 #include "cursors.h"
 #include "unlock_indicator.h"
+#include "xcb.h"
 
 extern auth_state_t auth_state;
 
@@ -73,15 +74,8 @@ static unsigned char mask_windows_bits[] = {
     0xf7, 0x00, 0xf3, 0x00, 0xe1, 0x01, 0xe0, 0x01, 0xc0, 0x03, 0xc0, 0x03,
     0x80, 0x01};
 
-static uint32_t get_colorpixel(char *hex) {
-    char strgroups[3][3] = {{hex[0], hex[1], '\0'},
-                            {hex[2], hex[3], '\0'},
-                            {hex[4], hex[5], '\0'}};
-    uint32_t rgb16[3] = {(strtol(strgroups[0], NULL, 16)),
-                         (strtol(strgroups[1], NULL, 16)),
-                         (strtol(strgroups[2], NULL, 16))};
-
-    return (rgb16[0] << 16) + (rgb16[1] << 8) + rgb16[2];
+static uint32_t get_colorpixel(rgba_t hex) {
+    return (hex.red << 16) + (hex.green << 8) + hex.blue;
 }
 
 xcb_visualtype_t *get_root_visual_type(xcb_screen_t *screen) {
@@ -106,7 +100,7 @@ xcb_visualtype_t *get_root_visual_type(xcb_screen_t *screen) {
     return NULL;
 }
 
-xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, char *color) {
+xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, rgba_t color) {
     xcb_pixmap_t bg_pixmap = xcb_generate_id(conn);
     xcb_create_pixmap(conn, scr->root_depth, bg_pixmap, scr->root,
                       resolution[0], resolution[1]);
@@ -123,7 +117,7 @@ xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32
     return bg_pixmap;
 }
 
-xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap) {
+xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, rgba_t color, xcb_pixmap_t pixmap) {
     uint32_t mask = 0;
     uint32_t values[3];
     xcb_window_t win = xcb_generate_id(conn);

--- a/xcb.h
+++ b/xcb.h
@@ -2,16 +2,20 @@
 #define _XCB_H
 
 #include <xcb/xcb.h>
+#include <xcb/xcb_xrm.h>
+
+#include "i3lock.h"
 
 extern xcb_connection_t *conn;
 extern xcb_screen_t *screen;
 
 xcb_visualtype_t *get_root_visual_type(xcb_screen_t *s);
-xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, char *color);
-xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, char *color, xcb_pixmap_t pixmap);
+xcb_pixmap_t create_bg_pixmap(xcb_connection_t *conn, xcb_screen_t *scr, u_int32_t *resolution, rgba_t color);
+xcb_window_t open_fullscreen_window(xcb_connection_t *conn, xcb_screen_t *scr, rgba_t color, xcb_pixmap_t pixmap);
 bool grab_pointer_and_keyboard(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor, int tries);
 xcb_cursor_t create_cursor(xcb_connection_t *conn, xcb_screen_t *screen, xcb_window_t win, int choice);
 xcb_window_t find_focused_window(xcb_connection_t *conn, const xcb_window_t root);
 void set_focused_window(xcb_connection_t *conn, const xcb_window_t root, const xcb_window_t window);
+void get_color_from_xrm(xcb_xrm_database_t *database, char *name, rgba_t *color);
 
 #endif


### PR DESCRIPTION
This PR adds support for changing the hardcoded colors and font using the X resource database system.

While I appreciate the simplicity of i3lock and its stance on feature-creep, I do find the state of its hardcoded styling somewhat sub-optimal for various reasons. For example, the color scheme may provide bad user experience for people with vision deficiencies such as color blindness or low contrast sensitivity. But also an interest in adapting the styling to fit in with the rest of ones system for a visually consistent experience should not be disregarded entirely.

Contrary to previous attempts at getting such a feature into i3lock, this implementation uses the X resource database system. This way no additional command-line arguments are introduced. XRDB is already used in i3lock to query the DPI setting, and using it to set styling preferences is also in line with i3wm, which also has a system allowing something similar.

I hope that this implementation manages to finally introduce a basic degree of styling, in a manner satisfying to both users and i3lock' maintainers. I'd ask to take this PR into consideration, not disregarding it immediately, even though it falls under personal opinion, as IMO a hardcoded styling is also opinionated, if not even more so ;).

PS:
For reference, skimming through the issues and PRs, this should also provide a solution for: #34, #94, #105, #197, #271