### PR TITLE
refresh image upon receiving USR1

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -97,6 +97,9 @@ bool tile = false;
 bool ignore_empty_password = false;
 bool skip_repeated_empty_password = false;
 
+/* Global, to allow it to be refreshed by signal handler */
+char *image_path = NULL;
+
 /* isutf, u8_dec © 2005 Jeff Bezanson, public domain */
 #define isutf(c) (((c)&0xC0) != 0x80)
 
@@ -1007,7 +1010,6 @@ static void raise_loop(xcb_window_t window) {
 int main(int argc, char *argv[]) {
     struct passwd *pw;
     char *username;
-    char *image_path = NULL;
     char *image_raw_format = NULL;
 #ifndef __OpenBSD__
     int ret;
@@ -1218,7 +1220,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    free(image_path);
+    // free(image_path);
     free(image_raw_format);
 
     /* Pixmap on which the image is rendered to (if any) */


### PR DESCRIPTION
Hi,

I've been using these proposed two patches on top of i3lock for quite some time now, and I'm testing the waters about whether they could be merged upstream instead of sitting in a branch, with no other user than myself.

The point of those patches is to allow refreshing the image used for locking the screen upon receiving a signal (i.e. `USR1`).

As to the use-case...

When one wants to use an amended screenshot of the current screen to lock their screen, they usually proceed as follows:

1. take screenshot
2. manipulate screenshot image
3. call i3lock with the manipulated image

The step at "2." may take quite a bit of time, and while "2." performs its tasks *the screen isn't yet locked*. If "2." moreover fails, it's possible the screen is never effectively locked.

With these patches, my process is now:

1. take screenshot
2. call i3lock with the just-screenshotted image (*quick*, and the *screen is now locked*)
3. manipulate screenshot image (may take however long, screen is still locked)
4. pkill -USR1 i3lock, which refreshes the image (screen is still locked, but now displays the new image)

In case the "3." step above takes an inordinate amount of time or fails, the screen is locked.