### PR TITLE
Changed background color

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -57,7 +57,7 @@
 typedef void (*ev_callback_t)(EV_P_ ev_timer *w, int revents);
 static void input_done(void);
 
-char color[7] = "ffffff";
+char color[7] = "a3a3a3";
 uint32_t last_resolution[2];
 xcb_window_t win;
 static xcb_cursor_t cursor;


### PR DESCRIPTION
Hi, I don't usually try to enforce my own defaults in my open-source contributions, however, as I poked around with the code of `i3lock` I came across the `color` variable.

When I initially tried out i3lock, I remember being woken up by the solid white lock screen color, and it's considerably hard on my own eyes when I'm even near my computer, let alone having to type the password itself. It was a bit tough, and I already even had a headache by the time that I logged in. I've also heard that super bright colors are frustrating to people with sensory issues (I haven't asked before making this change, so I can't be for sure as to whether my own change is helpful or speak for anyone else, but I'm bringing this up since that did happen to be one of the reasons as to why I made that one-line change. Please correct me if I'm wrong.).

I figured that a "pastel" dark color would be considerably better and much less annoying as a default than solid white. I thought of the AMOLED-friendly pitch black color, but, after using it as a default for quite some time, I had to stop, particularly because I had no idea whether my device was actually locked or shut off and I found that particularly frustrating when dealing with laptop lids. I'd be glad to discuss this a bit further and/or change the color.