### PR TITLE
Add GIF support for animated lock screen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,8 @@ AC_SEARCH_LIBS([ev_run], [ev], , [AC_MSG_FAILURE([cannot find the required ev_ru
 
 AC_SEARCH_LIBS([shm_open], [rt])
 
+AC_SEARCH_LIBS([DGifOpenFileName], [gif])
+
 # Only disable PAM on OpenBSD where i3lock uses BSD Auth instead
 case "$host" in
 	*-openbsd*)


### PR DESCRIPTION
Use gif_lib to read a GIF file [1] and show animated lock screen.
Currently it supports only 0-2 disposal methods.

[1] https://www.w3.org/Graphics/GIF/spec-gif89a.txt

![demonstation](https://user-images.githubusercontent.com/21184954/174704230-72f919ad-05d1-4b07-bb0b-f9884675c409.gif)
