### PR TITLE
Adding Space Mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2023-06-21 i3lock 2.14.2
+
+ • added Space Mode: mode where space presses aren't
+   registered until a password character is taken.
+
 2022-06-21 i3lock 2.14.1
 
  • unlock indicator: display only caps lock and num lock,

--- a/i3lock.c
+++ b/i3lock.c
@@ -74,7 +74,7 @@ bool unlock_indicator = true;
 char *modifier_string = NULL;
 static bool dont_fork = false;
 struct ev_loop *main_loop;
-static bool space_mode = true;
+static bool space_mode = false;
 static struct ev_timer *clear_auth_wrong_timeout;
 static struct ev_timer *clear_indicator_timeout;
 static struct ev_timer *discard_passwd_timeout;

--- a/i3lock.c
+++ b/i3lock.c
@@ -1088,7 +1088,7 @@ int main(int argc, char *argv[]) {
                 show_keyboard_layout = true;
                 break;
             default:
-                errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
+                errx(EXIT_FAILURE, "Syntax: i3lock [-v] [-s] [-n] [-b] [-d] [-c color] [-u] [-p win|default]"
                                    " [-i image.png] [-t] [-e] [-I timeout] [-f] [-k]");
         }
     }


### PR DESCRIPTION
I wake my computer by pressing the space bar, which adds the ' ' to the beginning of my password.

I am tired of this, so I added an option to enable "Space Mode", which prevents the system from taking the space key as a password character until a valid password character is processed.

I have this set to be 'opt-in' in case someone has their password start with ' '.