### PR TITLE
Update meson setup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ commands (might need to be adapted to your OS):
 rm -rf build/
 mkdir -p build && cd build/
 
-meson .. -Dprefix=/usr
+meson setup -Dprefix=/usr
 ninja
 ```
 


### PR DESCRIPTION
This is a very easy fix, when I run the README instructions `meson .. -Dprefix=/usr`, I get the following warning:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
The fix is to just run `meson setup -Dprefix=/usr` instead and it works like a charm.