### PR TITLE
Manpage: fix acute accent

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -91,7 +91,7 @@ Display the given PNG image instead of a blank screen.
 .BI \fB\-\-raw= format
 Read the image given by \-\-image as a raw image instead of PNG. The argument is the image's format
 as <width>x<height>:<pixfmt>. The supported pixel formats are:
-\'native', 'rgb', 'xrgb', 'rgbx', 'bgr', 'xbgr', and 'bgrx'.
+\(aqnative', \(aqrgb', \(aqxrgb', \(aqrgbx', \(aqbgr', \(aqxbgr', and \(aqbgrx'.
 The "native" pixel format expects a pixel as a 32-bit (4-byte) integer in
 the machine's native endianness, with the upper 8 bits unused. Red, green and blue are stored in
 the remaining bits, in that order.


### PR DESCRIPTION
Single opening quote needs to be written as `\(aq`