### PR TITLE
meson: use explicit_bzero if it is available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ endif
 
 cdata.set('HAVE_STRNDUP', cc.has_function('strndup'))
 cdata.set('HAVE_MKDIRP', cc.has_function('mkdirp'))
+cdata.set('HAVE_EXPLICIT_BZERO', cc.has_function('explicit_bzero'))
 
 # Instead of generating config.h directly, make vcs_tag generate it so that
 # @VCS_TAG@ is replaced.


### PR DESCRIPTION
It seems that the check for explicit_bzero was lost during the conversion to meson build system.