### PR TITLE
Support sequential PAM conversations in i3lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 # it is up to you to arrange for it to be ignored by git,
 # e.g. by listing your directory in .git/info/exclude.
 /build
+.claude

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Running i3lock
 To test i3lock, you can directly run the `i3lock` command. To get out of it,
 enter your password and press enter.
 
+i3lock authenticates through the system PAM service named `i3lock` on Linux.
+It supports standard sequential PAM conversations: informational messages,
+error messages, hidden prompts, and visible prompts are handled in the order
+provided by PAM. Hidden prompts keep the normal masked lock-screen behaviour;
+visible prompts echo the entered text as requested by PAM. Pressing Escape
+cancels the active PAM conversation from i3lock's side and returns to the
+locked input state. i3lock never logs entered credentials.
+
 For a more permanent setup, we strongly recommend using `xss-lock` so that the
 screen is locked *before* your laptop suspends:
 

--- a/i3lock-pam-suppport-plan.md
+++ b/i3lock-pam-suppport-plan.md
@@ -1,0 +1,169 @@
+# Sequential PAM conversations for i3lock
+
+## Summary
+
+Implement sequential PAM support in five reviewable milestones. The first product target is Himmelblau/Entra; the
+architecture supports standard Linux-PAM conversations and leaves room for a later explicit automatic biometric flow.
+
+The external harness remains the end-to-end test suite. OpenBSD bsd_auth remains unchanged.
+
+## 1. Strengthen the external harness
+
+- Extend the bridge protocol with one genuine multi-message pam_conv batch command, preserving each message’s original
+  index.
+
+- Add passing baseline characterisation tests against current i3lock:
+  - repeated hidden prompts replay one submitted buffer;
+  - a mixed TEXT_INFO / ECHO_OFF / ECHO_ON batch reaches one callback;
+  - the Himmelblau replay remains reproducible.
+
+- Add controllable backend-delay scenarios so cancellation can be tested both while PAM is waiting for input and while
+  pam_authenticate() is between callbacks.
+
+Gate: make test passes against unmodified local i3lock.
+
+## 2. Add the fork-safe controller foundation
+
+- Remove early PAM initialization. Do not create controller state, synchronization primitives, pipe descriptors, or
+  threads before both existing forks are complete.
+
+- Start the controller exactly once in the first XCB_MAP_NOTIFY handler:
+  - if daemonizing is enabled, only at the end of the child continuation after fork() and ev_loop_fork(EV_DEFAULT);
+  - if --nofork is set, at the same point after that skipped-fork conditional;
+  - use a dedicated controller_started guard, not dont_fork, to make this explicit.
+
+- The earlier raise-loop fork has already completed by this point. No i3lock fork may occur after controller
+  initialization.
+
+- The worker owns pam_start, pam_set_item, pam_authenticate, pam_setcred, and pam_end. It creates/configures an idle
+  handle after startup but does not authenticate yet.
+
+- Add the fundamental safety mechanisms now:
+  - monotonic transaction IDs and prompt IDs;
+  - mutex-protected event queue plus libev-watched wake-up pipe;
+  - one bounded secure-storage region for UI input, deferred input, and pending responses; mlock() it once and abort if
+    locking fails, matching i3lock's existing password-memory policy;
+  - immediate wiping of i3lock-owned copies on transfer, failure, and cancellation;
+  - removal of credential values from debug output.
+
+Gate: Ordinary hidden-password success/failure remains functional in both normal daemonizing and --nofork harness runs; no
+worker exists before the final process is established.
+
+## 3. Implement the sequential PAM state machine
+
+Use these explicit controller states:
+
+State                Meaning and allowed transition
+━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+IDLE                 PAM handle ready; user may type. Enter stages one deferred submission and moves to AUTH_STARTING.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+AUTH_STARTING        Worker begins pam_authenticate(). It moves to AUTH_RUNNING or WAITING_PROMPT. Escape moves to
+AUTH_CANCELLING.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+AUTH_RUNNING         PAM is active without an outstanding input prompt. It may emit status, request a prompt, complete,
+or receive cancellation.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+WAITING_PROMPT       One identified prompt waits for a matching fresh answer. Submit moves to AUTH_RUNNING; Escape moves
+to AUTH_CANCELLING.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+AUTH_CANCELLING      Transaction is invalidated and UI is idle-looking; worker cleanup is outstanding. A later Enter is
+retained as pending intent. Completion moves to IDLE or immediately starts that pending intent.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+AUTH_FAILED_DELAY    Active transaction has completed unsuccessfully; existing Wrong! delay applies. Input/Enter queues
+one retry. Timer expiry moves to IDLE or starts the queued retry.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+AUTH_SUCCEEDED       Active transaction completed successfully; worker refreshes credentials and cleans up, then the
+main loop exits.
+───────────────────  ─────────────────────────────────────────────────────────────────────────────────────────────────────
+AUTH_FATAL           PAM_ABORT ended the handle. i3lock stays locked with a fatal authentication-service error and does
+not retry.
+
+- Every worker event includes transaction_id; prompt events and submitted answers include prompt_id.
+  - The UI accepts only events for the active transaction and prompt.
+  - Retired transaction events, including late success, can never update UI or unlock.
+
+- Enter starts pam_authenticate() only for an explicit user submission.
+  - The deferred value answers only the first actual PAM_PROMPT_ECHO_OFF.
+  - If the first input prompt is PAM_PROMPT_ECHO_ON, securely discard the deferred masked value, display the visible
+    prompt, and require visible re-entry.
+
+  - Every later prompt requires fresh input.
+
+- Escape invalidates transaction authority immediately.
+  - If the worker is waiting in pam_conv, signal its condition variable and return PAM_CONV_ERR.
+  - If the worker is inside backend work between callbacks, set cancellation requested but do not attempt to interrupt
+    PAM; the worker checks cancellation before the next prompt and again after pam_authenticate() returns.
+
+  - A cancelled transaction never refreshes credentials or unlocks, even if PAM later returns success.
+  - The UI does not block waiting for worker termination. One pending post-cancel user submission is stored only in the
+    bounded mlocked controller buffer until cleanup completes.
+
+- Map controller states onto the existing indicator enums without replacing their current meaning: AUTH_STARTING and
+  AUTH_RUNNING use STATE_AUTH_VERIFY; WAITING_PROMPT uses normal input/STATE_AUTH_IDLE presentation; AUTH_FAILED_DELAY
+  uses STATE_AUTH_WRONG; AUTH_FATAL uses STATE_I3LOCK_LOCK_FAILED. Existing unlock states continue to drive keypress,
+  backspace, and input highlighting.
+
+Gate: Harness proves wrong Himmelblau PIN followed by a fresh correct PIN succeeds, prompt IDs reject stale answers, and
+cancellation during both prompt wait and backend delay cannot unlock.
+
+## 4. Implement complete PAM batches and presentation
+
+- Process each pam_conv(num_msg, ...) call atomically in the worker:
+  1. Allocate one zeroed pam_response[num_msg].
+  2. Process messages in index order.
+  3. For PAM_TEXT_INFO and PAM_ERROR_MSG, enqueue status and retain resp[index] = NULL.
+  4. For every ECHO_OFF or ECHO_ON prompt, wait for its matching prompt ID and write the response at the same index.
+  5. Return success only after all prompts are answered.
+  6. On cancellation, unsupported style, or allocation failure, wipe/free values still owned by i3lock and return
+     PAM_CONV_ERR. After successful callback return, never touch PAM-owned response strings.
+
+- Maintain prompt presentation metadata, not separate semantics:
+  - LATENT means an active first standalone hidden prompt whose provider label is not rendered; i3lock keeps its
+    ordinary masked-input indicator with no grey label or additional waiting state;
+  - only a first standalone hidden prompt may be LATENT;
+  - all prompts remain real active prompts regardless of visibility;
+  - preceding info/error, visible input, or any later prompt forces visible presentation;
+  - never infer prompt meaning from text.
+
+- Render retained provider status and active prompt below the indicator:
+  - up to two wrapped UTF-8 status lines plus one prompt line;
+  - ellipsis truncate excess text;
+  - style PAM_ERROR_MSG as error without treating it as a terminal failure;
+  - persist status until superseded or transaction completion;
+  - visibly echo ECHO_ON; mask ECHO_OFF.
+
+- On terminal failure, clear provider text and retain the current Wrong! delay and retry behaviour.
+
+Gate: Harness validates response index ordering for a mixed batch; Xephyr confirms ordinary password stays visually quiet
+while Himmelblau PIN/password/MFA text is understandable and survives retry delays.
+
+## 5. Stabilize and document
+
+- Exercise daemonizing, --nofork, cancellation, late completion, retry, and repeated cleanup paths.
+- The worker exclusively owns every PAM handle. On successful, non-cancelled authentication it calls
+  pam_setcred(PAM_REFRESH_CRED) before posting success, then calls pam_end; the main thread never accesses that handle.
+  Preserve current behaviour by not downgrading a successful authentication solely because credential refresh fails.
+- Define terminal PAM errors explicitly: PAM_ABORT ends its handle and enters AUTH_FATAL, leaving i3lock locked with a
+  fatal service-error display and no retry. PAM_SYSTEM_ERR and PAM_SERVICE_ERR end and discard the handle, display an
+  error through the normal failure delay, and permit a fresh transaction afterwards.
+- Review each terminal path for pam_end status, transaction retirement, worker cleanup, and secret wiping.
+- Update i3lock documentation for:
+  - sequential standard PAM conversations;
+  - visible-input prompts;
+  - Escape cancellation semantics;
+  - no credential logging.
+
+- Update harness documentation with the final Himmelblau and mixed-batch regression coverage.
+
+Gate: Full harness suite passes against a clean local i3lock build, with no changes to system PAM configuration,
+Himmelblau, Entra, or host lock state.
+
+## Non-negotiable invariants
+
+- No controller thread or synchronization primitive exists before i3lock’s final fork point.
+- Exactly one PAM transaction is active at a time.
+- Every UI-affecting event and answer is transaction/prompt identified.
+- PAM batch response indexes exactly match PAM message indexes.
+- Cancellation removes unlock/UI authority immediately, even if backend PAM work continues.
+- The worker exclusively owns each PAM handle, including pam_setcred and pam_end.
+- i3lock wipes every credential copy it controls and never logs entered credentials.

--- a/i3lock.c
+++ b/i3lock.c
@@ -41,6 +41,9 @@
 #include <xcb/randr.h>
 
 #include "i3lock.h"
+#ifndef __OpenBSD__
+#include "pam_controller.h"
+#endif
 #include "xcb.h"
 #include "cursors.h"
 #include "unlock_indicator.h"
@@ -62,8 +65,10 @@ uint32_t last_resolution[2];
 xcb_window_t win;
 static xcb_cursor_t cursor;
 #ifndef __OpenBSD__
-static pam_handle_t *pam_handle;
-static bool pam_cleanup;
+static bool controller_started = false;
+static uint64_t active_pam_transaction_id = 0;
+static struct ev_io *pam_watcher = NULL;
+static char *saved_username = NULL;
 #endif
 int input_position = 0;
 /* Holds the password you enter (in UTF-8). */
@@ -275,8 +280,77 @@ static void discard_passwd_cb(EV_P_ ev_timer *w, int revents) {
     STOP_TIMER(discard_passwd_timeout);
 }
 
+static void auth_failed(void) {
+    if (debug_mode) {
+        fprintf(stderr, "Authentication failure\n");
+    }
+
+    auth_state = STATE_AUTH_WRONG;
+    if (failed_attempts < 999) {
+        failed_attempts += 1;
+    }
+    clear_input();
+    if (unlock_indicator) {
+        redraw_screen();
+    }
+
+    ev_now_update(main_loop);
+    START_TIMER(clear_auth_wrong_timeout, TSTAMP_N_SECS(2), clear_auth_wrong);
+    STOP_TIMER(clear_indicator_timeout);
+
+    if (beep) {
+        xcb_bell(conn, 100);
+        xcb_flush(conn);
+    }
+}
+
+#ifndef __OpenBSD__
+static void handle_pam_event(const pam_event_t *event) {
+    switch (event->type) {
+        case PAM_EVENT_AUTH_READY:
+            return;
+
+        case PAM_EVENT_AUTH_SUCCESS:
+            if (event->transaction_id != active_pam_transaction_id) {
+                return;
+            }
+            DEBUG("successfully authenticated\n");
+            clear_password_memory();
+            ev_break(EV_DEFAULT, EVBREAK_ALL);
+            return;
+
+        case PAM_EVENT_AUTH_FAILURE:
+            if (event->transaction_id != active_pam_transaction_id) {
+                return;
+            }
+            active_pam_transaction_id = 0;
+            auth_failed();
+            return;
+
+        case PAM_EVENT_AUTH_FATAL:
+            active_pam_transaction_id = 0;
+            auth_state = STATE_I3LOCK_LOCK_FAILED;
+            clear_input();
+            redraw_screen();
+            return;
+    }
+}
+
+static void pam_event_cb(EV_P_ ev_io *w, int revents) {
+    (void)w;
+    (void)revents;
+    pam_controller_drain_events(handle_pam_event);
+}
+#endif
+
 static void input_done(void) {
     STOP_TIMER(clear_auth_wrong_timeout);
+
+    /* Do not start a second authentication while one is in progress. */
+    if (auth_state == STATE_AUTH_VERIFY) {
+        return;
+    }
+
     auth_state = STATE_AUTH_VERIFY;
     unlock_state = STATE_STARTED;
     redraw_screen();
@@ -295,52 +369,23 @@ static void input_done(void) {
         ev_break(EV_DEFAULT, EVBREAK_ALL);
         return;
     }
+
+    auth_failed();
 #else
-    if (pam_authenticate(pam_handle, 0) == PAM_SUCCESS) {
-        DEBUG("successfully authenticated\n");
-        clear_password_memory();
-
-        /* PAM credentials should be refreshed, this will for example update any kerberos tickets.
-         * Related to credentials pam_end() needs to be called to cleanup any temporary
-         * credentials like kerberos /tmp/krb5cc_pam_* files which may of been left behind if the
-         * refresh of the credentials failed. */
-        pam_setcred(pam_handle, PAM_REFRESH_CRED);
-        pam_cleanup = true;
-
-        ev_break(EV_DEFAULT, EVBREAK_ALL);
+    if (!controller_started) {
+        auth_state = STATE_I3LOCK_LOCK_FAILED;
+        redraw_screen();
         return;
     }
-#endif
 
-    if (debug_mode) {
-        fprintf(stderr, "Authentication failure\n");
-    }
-
-    auth_state = STATE_AUTH_WRONG;
-    /* The unlock indicator displays the number of failed attempts,
-     * but caps the attempts to 999, so only increment up to 999. */
-    if (failed_attempts < 999) {
-        failed_attempts += 1;
-    }
-    clear_input();
-    if (unlock_indicator) {
+    active_pam_transaction_id = pam_controller_start_auth(password);
+    if (active_pam_transaction_id == 0) {
+        auth_state = STATE_I3LOCK_LOCK_FAILED;
         redraw_screen();
+        return;
     }
-
-    /* Clear this state after 2 seconds (unless the user enters another
-     * password during that time). */
-    ev_now_update(main_loop);
-    START_TIMER(clear_auth_wrong_timeout, TSTAMP_N_SECS(2), clear_auth_wrong);
-
-    /* Cancel the clear_indicator_timeout, it would hide the unlock indicator
-     * too early. */
-    STOP_TIMER(clear_indicator_timeout);
-
-    /* beep on authentication failure, if enabled */
-    if (beep) {
-        xcb_bell(conn, 100);
-        xcb_flush(conn);
-    }
+    clear_password_memory();
+#endif
 }
 
 static void redraw_timeout(EV_P_ ev_timer *w, int revents) {
@@ -505,7 +550,7 @@ static void handle_key_press(xcb_key_press_event_t *event) {
     /* store it in the password array as UTF-8 */
     memcpy(password + input_position, buffer, n - 1);
     input_position += n - 1;
-    DEBUG("current password = %.*s\n", input_position, password);
+    DEBUG("key accepted, input_position = %d\n", input_position);
 
     if (unlock_indicator) {
         unlock_state = STATE_KEY_ACTIVE;
@@ -808,40 +853,7 @@ static bool verify_png_image(const char *image_path) {
     return true;
 }
 
-#ifndef __OpenBSD__
-/*
- * Callback function for PAM. We only react on password request callbacks.
- *
- */
-static int conv_callback(int num_msg, const struct pam_message **msg,
-                         struct pam_response **resp, void *appdata_ptr) {
-    if (num_msg == 0) {
-        return 1;
-    }
-
-    /* PAM expects an array of responses, one for each message */
-    if ((*resp = calloc(num_msg, sizeof(struct pam_response))) == NULL) {
-        perror("calloc");
-        return 1;
-    }
-
-    for (int c = 0; c < num_msg; c++) {
-        if (msg[c]->msg_style != PAM_PROMPT_ECHO_OFF &&
-            msg[c]->msg_style != PAM_PROMPT_ECHO_ON) {
-            continue;
-        }
-
-        /* return code is currently not used but should be set to zero */
-        resp[c]->resp_retcode = 0;
-        if ((resp[c]->resp = strdup(password)) == NULL) {
-            perror("strdup");
-            return 1;
-        }
-    }
-
-    return 0;
-}
-#endif
+/* conv_callback has moved to pam_controller.c (worker_conv_callback). */
 
 /*
  * This callback is only a dummy, see xcb_prepare_cb and xcb_check_cb.
@@ -925,6 +937,19 @@ static void xcb_check_cb(EV_P_ ev_check *w, int revents) {
 
                     ev_loop_fork(EV_DEFAULT);
                 }
+#ifndef __OpenBSD__
+                if (!controller_started) {
+                    controller_started = true;
+                    pam_controller_init(saved_username, getenv("DISPLAY"));
+                    pam_watcher = calloc(1, sizeof(struct ev_io));
+                    if (pam_watcher == NULL) {
+                        errx(EXIT_FAILURE, "calloc pam_watcher");
+                    }
+                    ev_io_init(pam_watcher, pam_event_cb,
+                               pam_controller_get_fd(), EV_READ);
+                    ev_io_start(main_loop, pam_watcher);
+                }
+#endif
                 break;
 
             case XCB_CONFIGURE_NOTIFY:
@@ -1010,10 +1035,6 @@ int main(int argc, char *argv[]) {
     char *username;
     char *image_path = NULL;
     char *image_raw_format = NULL;
-#ifndef __OpenBSD__
-    int ret;
-    struct pam_conv conv = {conv_callback, NULL};
-#endif
     int curs_choice = CURS_NONE;
     int o;
     int longoptind = 0;
@@ -1118,6 +1139,9 @@ int main(int argc, char *argv[]) {
     if ((username = pw->pw_name) == NULL) {
         errx(EXIT_FAILURE, "pw->pw_name is NULL.");
     }
+#ifndef __OpenBSD__
+    saved_username = username;
+#endif
     if (getenv("WAYLAND_DISPLAY") != NULL) {
         errx(EXIT_FAILURE, "i3lock is a program for X11 and does not work on Wayland. Try https://github.com/swaywm/swaylock instead");
     }
@@ -1126,16 +1150,8 @@ int main(int argc, char *argv[]) {
      * the unlock indicator upon keypresses. */
     srand(time(NULL));
 
-#ifndef __OpenBSD__
-    /* Initialize PAM */
-    if ((ret = pam_start("i3lock", username, &conv, &pam_handle)) != PAM_SUCCESS) {
-        errx(EXIT_FAILURE, "PAM: %s", pam_strerror(pam_handle, ret));
-    }
-
-    if ((ret = pam_set_item(pam_handle, PAM_TTY, getenv("DISPLAY"))) != PAM_SUCCESS) {
-        errx(EXIT_FAILURE, "PAM: %s", pam_strerror(pam_handle, ret));
-    }
-#endif
+    /* PAM initialisation has moved to pam_controller_init(), called from
+     * the first XCB_MAP_NOTIFY handler after the daemonisation fork. */
 
 /* Using mlock() as non-super-user seems only possible in Linux.
  * Users of other operating systems should use encrypted swap/no swap
@@ -1325,9 +1341,8 @@ int main(int argc, char *argv[]) {
     ev_loop(main_loop, 0);
 
 #ifndef __OpenBSD__
-    if (pam_cleanup) {
-        pam_end(pam_handle, PAM_SUCCESS);
-    }
+    pam_controller_cleanup();
+    free(pam_watcher);
 #endif
 
     if (stolen_focus == XCB_NONE) {

--- a/i3lock.c
+++ b/i3lock.c
@@ -1027,6 +1027,12 @@ static void xcb_prepare_cb(EV_P_ ev_prepare *w, int revents) {
  *
  */
 static void maybe_close_sleep_lock_fd(void) {
+    static bool sleep_lock_fd_closed = false;
+    if (sleep_lock_fd_closed) {
+        return;
+    }
+    sleep_lock_fd_closed = true;
+
     const char *sleep_lock_fd = getenv("XSS_SLEEP_LOCK_FD");
     char *endptr;
     if (sleep_lock_fd && *sleep_lock_fd != 0) {
@@ -1034,6 +1040,15 @@ static void maybe_close_sleep_lock_fd(void) {
         if (*endptr == 0) {
             close(fd);
         }
+        unsetenv("XSS_SLEEP_LOCK_FD");
+    }
+}
+
+static void stay_locked_after_lock_failure(void) {
+    auth_state = STATE_I3LOCK_LOCK_FAILED;
+    redraw_screen();
+    while (true) {
+        pause();
     }
 }
 
@@ -1060,6 +1075,7 @@ static void xcb_check_cb(EV_P_ ev_check *w, int revents) {
             continue;
         }
 
+        bool synthetic_event = (event->response_type & 0x80) != 0;
         /* Strip off the highest bit (set if the event is generated) */
         int type = (event->response_type & 0x7F);
 
@@ -1073,18 +1089,24 @@ static void xcb_check_cb(EV_P_ ev_check *w, int revents) {
                 break;
 
             case XCB_MAP_NOTIFY:
+                if (synthetic_event) {
+                    break;
+                }
                 maybe_close_sleep_lock_fd();
                 if (!dont_fork) {
                     /* After the first MapNotify, we never fork again. We don’t
                      * expect to get another MapNotify, but better be sure… */
                     dont_fork = true;
 
-                    /* In the parent process, we exit */
-                    if (fork() != 0) {
+                    pid_t fork_result = fork();
+                    if (fork_result == -1) {
+                        fprintf(stderr, "[i3lock] could not daemonize after locking; continuing in foreground\n");
+                    } else if (fork_result != 0) {
+                        /* In the parent process, we exit */
                         exit(0);
+                    } else {
+                        ev_loop_fork(EV_DEFAULT);
                     }
-
-                    ev_loop_fork(EV_DEFAULT);
                 }
 #ifndef __OpenBSD__
                 if (!controller_started) {
@@ -1485,6 +1507,12 @@ int main(int argc, char *argv[]) {
     struct ev_io *xcb_watcher = calloc(1, sizeof(struct ev_io));
     struct ev_check *xcb_check = calloc(1, sizeof(struct ev_check));
     struct ev_prepare *xcb_prepare = calloc(1, sizeof(struct ev_prepare));
+    if (xcb_watcher == NULL || xcb_check == NULL || xcb_prepare == NULL) {
+        free(xcb_watcher);
+        free(xcb_check);
+        free(xcb_prepare);
+        stay_locked_after_lock_failure();
+    }
 
     ev_io_init(xcb_watcher, xcb_got_event, xcb_get_file_descriptor(conn), EV_READ);
     ev_io_start(main_loop, xcb_watcher);

--- a/i3lock.c
+++ b/i3lock.c
@@ -383,6 +383,7 @@ static void handle_pam_event(const pam_event_t *event) {
 
         case PAM_EVENT_AUTH_SUCCESS:
             if (event->transaction_id != active_pam_transaction_id) {
+                pam_controller_ack_terminal(event->transaction_id);
                 return;
             }
             DEBUG("successfully authenticated\n");
@@ -391,11 +392,13 @@ static void handle_pam_event(const pam_event_t *event) {
             pam_waiting_for_prompt = false;
             clear_pam_display_text();
             clear_password_memory();
+            pam_controller_ack_terminal(event->transaction_id);
             ev_break(EV_DEFAULT, EVBREAK_ALL);
             return;
 
         case PAM_EVENT_AUTH_FAILURE:
             if (event->transaction_id != active_pam_transaction_id) {
+                pam_controller_ack_terminal(event->transaction_id);
                 return;
             }
             active_pam_transaction_id = 0;
@@ -410,10 +413,12 @@ static void handle_pam_event(const pam_event_t *event) {
                 clear_pam_display_text();
             }
             auth_failed();
+            pam_controller_ack_terminal(event->transaction_id);
             return;
 
         case PAM_EVENT_AUTH_CANCELLED:
             if (event->transaction_id != active_pam_transaction_id) {
+                pam_controller_ack_terminal(event->transaction_id);
                 return;
             }
             active_pam_transaction_id = 0;
@@ -422,6 +427,7 @@ static void handle_pam_event(const pam_event_t *event) {
             clear_pam_display_text();
             auth_state = STATE_AUTH_IDLE;
             redraw_screen();
+            pam_controller_ack_terminal(event->transaction_id);
             return;
 
         case PAM_EVENT_AUTH_FATAL:
@@ -440,6 +446,7 @@ static void handle_pam_event(const pam_event_t *event) {
             auth_state = STATE_I3LOCK_LOCK_FAILED;
             clear_input();
             redraw_screen();
+            pam_controller_ack_terminal(event->transaction_id);
             return;
     }
 }

--- a/i3lock.c
+++ b/i3lock.c
@@ -59,6 +59,7 @@
 
 typedef void (*ev_callback_t)(EV_P_ ev_timer *w, int revents);
 static void input_done(void);
+static void clear_pam_display_text(void);
 
 char color[7] = "a3a3a3";
 uint32_t last_resolution[2];
@@ -69,6 +70,7 @@ static bool controller_started = false;
 static uint64_t active_pam_transaction_id = 0;
 static uint64_t active_pam_prompt_id = 0;
 static bool pam_waiting_for_prompt = false;
+static bool pam_auth_fatal = false;
 static struct ev_io *pam_watcher = NULL;
 static char *saved_username = NULL;
 #endif
@@ -84,6 +86,7 @@ char pam_prompt_text[I3LOCK_PAM_UI_TEXT_MAX];
 char pam_visible_input[I3LOCK_PAM_VISIBLE_INPUT_MAX];
 bool pam_status_is_error = false;
 bool pam_prompt_echo_on = false;
+static bool pam_status_expires_with_auth_wrong = false;
 static bool dont_fork = false;
 struct ev_loop *main_loop;
 static struct ev_timer *clear_auth_wrong_timeout;
@@ -253,6 +256,9 @@ static void finish_input(void) {
 static void clear_auth_wrong(EV_P_ ev_timer *w, int revents) {
     DEBUG("clearing auth wrong\n");
     auth_state = STATE_AUTH_IDLE;
+    if (pam_status_expires_with_auth_wrong) {
+        clear_pam_display_text();
+    }
     redraw_screen();
 
     /* Clear modifier string. */
@@ -318,6 +324,7 @@ static void clear_pam_display_text(void) {
     pam_visible_input[0] = '\0';
     pam_status_is_error = false;
     pam_prompt_echo_on = false;
+    pam_status_expires_with_auth_wrong = false;
 }
 
 static void update_pam_visible_input(void) {
@@ -345,6 +352,7 @@ static void handle_pam_event(const pam_event_t *event) {
             }
             snprintf(pam_status_text, sizeof(pam_status_text), "%s", event->text);
             pam_status_is_error = event->is_error;
+            pam_status_expires_with_auth_wrong = false;
             redraw_screen();
             return;
 
@@ -383,7 +391,14 @@ static void handle_pam_event(const pam_event_t *event) {
             active_pam_transaction_id = 0;
             active_pam_prompt_id = 0;
             pam_waiting_for_prompt = false;
-            clear_pam_display_text();
+            if (event->text[0] != '\0') {
+                clear_pam_display_text();
+                snprintf(pam_status_text, sizeof(pam_status_text), "%s", event->text);
+                pam_status_is_error = event->is_error;
+                pam_status_expires_with_auth_wrong = true;
+            } else {
+                clear_pam_display_text();
+            }
             auth_failed();
             return;
 
@@ -403,7 +418,15 @@ static void handle_pam_event(const pam_event_t *event) {
             active_pam_transaction_id = 0;
             active_pam_prompt_id = 0;
             pam_waiting_for_prompt = false;
-            clear_pam_display_text();
+            pam_auth_fatal = true;
+            if (event->text[0] != '\0') {
+                clear_pam_display_text();
+                snprintf(pam_status_text, sizeof(pam_status_text), "%s", event->text);
+                pam_status_is_error = event->is_error;
+                pam_status_expires_with_auth_wrong = false;
+            } else {
+                clear_pam_display_text();
+            }
             auth_state = STATE_I3LOCK_LOCK_FAILED;
             clear_input();
             redraw_screen();
@@ -420,6 +443,15 @@ static void pam_event_cb(EV_P_ ev_io *w, int revents) {
 
 static void input_done(void) {
     STOP_TIMER(clear_auth_wrong_timeout);
+
+#ifndef __OpenBSD__
+    if (pam_auth_fatal) {
+        auth_state = STATE_I3LOCK_LOCK_FAILED;
+        clear_input();
+        redraw_screen();
+        return;
+    }
+#endif
 
     /* Do not start a second authentication while one is in progress. */
     if (auth_state == STATE_AUTH_VERIFY) {

--- a/i3lock.c
+++ b/i3lock.c
@@ -67,6 +67,8 @@ static xcb_cursor_t cursor;
 #ifndef __OpenBSD__
 static bool controller_started = false;
 static uint64_t active_pam_transaction_id = 0;
+static uint64_t active_pam_prompt_id = 0;
+static bool pam_waiting_for_prompt = false;
 static struct ev_io *pam_watcher = NULL;
 static char *saved_username = NULL;
 #endif
@@ -77,6 +79,11 @@ static bool beep = false;
 bool debug_mode = false;
 bool unlock_indicator = true;
 char *modifier_string = NULL;
+char pam_status_text[I3LOCK_PAM_UI_TEXT_MAX];
+char pam_prompt_text[I3LOCK_PAM_UI_TEXT_MAX];
+char pam_visible_input[I3LOCK_PAM_VISIBLE_INPUT_MAX];
+bool pam_status_is_error = false;
+bool pam_prompt_echo_on = false;
 static bool dont_fork = false;
 struct ev_loop *main_loop;
 static struct ev_timer *clear_auth_wrong_timeout;
@@ -273,6 +280,7 @@ static void clear_input(void) {
     input_position = 0;
     clear_password_memory();
     password[input_position] = '\0';
+    pam_visible_input[0] = '\0';
 }
 
 static void discard_passwd_cb(EV_P_ ev_timer *w, int revents) {
@@ -304,10 +312,55 @@ static void auth_failed(void) {
     }
 }
 
+static void clear_pam_display_text(void) {
+    pam_status_text[0] = '\0';
+    pam_prompt_text[0] = '\0';
+    pam_visible_input[0] = '\0';
+    pam_status_is_error = false;
+    pam_prompt_echo_on = false;
+}
+
+static void update_pam_visible_input(void) {
+    if (pam_prompt_echo_on) {
+        size_t len = strlen(password);
+        if (len >= sizeof(pam_visible_input)) {
+            len = sizeof(pam_visible_input) - 1;
+        }
+        memcpy(pam_visible_input, password, len);
+        pam_visible_input[len] = '\0';
+    } else {
+        pam_visible_input[0] = '\0';
+    }
+}
+
 #ifndef __OpenBSD__
 static void handle_pam_event(const pam_event_t *event) {
     switch (event->type) {
         case PAM_EVENT_AUTH_READY:
+            return;
+
+        case PAM_EVENT_AUTH_STATUS:
+            if (event->transaction_id != active_pam_transaction_id) {
+                return;
+            }
+            snprintf(pam_status_text, sizeof(pam_status_text), "%s", event->text);
+            pam_status_is_error = event->is_error;
+            redraw_screen();
+            return;
+
+        case PAM_EVENT_AUTH_PROMPT:
+            if (event->transaction_id != active_pam_transaction_id) {
+                return;
+            }
+            active_pam_prompt_id = event->prompt_id;
+            pam_waiting_for_prompt = true;
+            snprintf(pam_prompt_text, sizeof(pam_prompt_text), "%s", event->text);
+            pam_prompt_echo_on = event->echo_on;
+            pam_visible_input[0] = '\0';
+            auth_state = STATE_AUTH_IDLE;
+            unlock_state = STATE_KEY_PRESSED;
+            clear_input();
+            redraw_screen();
             return;
 
         case PAM_EVENT_AUTH_SUCCESS:
@@ -315,6 +368,10 @@ static void handle_pam_event(const pam_event_t *event) {
                 return;
             }
             DEBUG("successfully authenticated\n");
+            active_pam_transaction_id = 0;
+            active_pam_prompt_id = 0;
+            pam_waiting_for_prompt = false;
+            clear_pam_display_text();
             clear_password_memory();
             ev_break(EV_DEFAULT, EVBREAK_ALL);
             return;
@@ -324,11 +381,29 @@ static void handle_pam_event(const pam_event_t *event) {
                 return;
             }
             active_pam_transaction_id = 0;
+            active_pam_prompt_id = 0;
+            pam_waiting_for_prompt = false;
+            clear_pam_display_text();
             auth_failed();
+            return;
+
+        case PAM_EVENT_AUTH_CANCELLED:
+            if (event->transaction_id != active_pam_transaction_id) {
+                return;
+            }
+            active_pam_transaction_id = 0;
+            active_pam_prompt_id = 0;
+            pam_waiting_for_prompt = false;
+            clear_pam_display_text();
+            auth_state = STATE_AUTH_IDLE;
+            redraw_screen();
             return;
 
         case PAM_EVENT_AUTH_FATAL:
             active_pam_transaction_id = 0;
+            active_pam_prompt_id = 0;
+            pam_waiting_for_prompt = false;
+            clear_pam_display_text();
             auth_state = STATE_I3LOCK_LOCK_FAILED;
             clear_input();
             redraw_screen();
@@ -372,6 +447,23 @@ static void input_done(void) {
 
     auth_failed();
 #else
+    if (pam_waiting_for_prompt) {
+        uint64_t transaction_id = active_pam_transaction_id;
+        uint64_t prompt_id = active_pam_prompt_id;
+        pam_waiting_for_prompt = false;
+        active_pam_prompt_id = 0;
+        pam_prompt_text[0] = '\0';
+        pam_visible_input[0] = '\0';
+        pam_prompt_echo_on = false;
+        auth_state = STATE_AUTH_VERIFY;
+        if (!pam_controller_submit_answer(transaction_id, prompt_id, password)) {
+            auth_state = STATE_AUTH_IDLE;
+        }
+        clear_password_memory();
+        redraw_screen();
+        return;
+    }
+
     if (!controller_started) {
         auth_state = STATE_I3LOCK_LOCK_FAILED;
         redraw_screen();
@@ -380,10 +472,12 @@ static void input_done(void) {
 
     active_pam_transaction_id = pam_controller_start_auth(password);
     if (active_pam_transaction_id == 0) {
-        auth_state = STATE_I3LOCK_LOCK_FAILED;
+        auth_state = STATE_AUTH_IDLE;
+        clear_password_memory();
         redraw_screen();
         return;
     }
+    clear_pam_display_text();
     clear_password_memory();
 #endif
 }
@@ -485,6 +579,16 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             if ((ksym == XKB_KEY_u && ctrl) ||
                 ksym == XKB_KEY_Escape) {
                 DEBUG("C-u pressed\n");
+#ifndef __OpenBSD__
+                if (ksym == XKB_KEY_Escape && active_pam_transaction_id != 0) {
+                    pam_controller_cancel_auth(active_pam_transaction_id);
+                    active_pam_transaction_id = 0;
+                    active_pam_prompt_id = 0;
+                    pam_waiting_for_prompt = false;
+                    clear_pam_display_text();
+                    auth_state = STATE_AUTH_IDLE;
+                }
+#endif
                 clear_input();
                 /* Also hide the unlock indicator */
                 if (unlock_indicator) {
@@ -518,6 +622,7 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             /* decrement input_position to point to the previous glyph */
             u8_dec(password, &input_position);
             password[input_position] = '\0';
+            update_pam_visible_input();
 
             /* Hide the unlock indicator after a bit if the password buffer is
              * empty. */
@@ -550,6 +655,8 @@ static void handle_key_press(xcb_key_press_event_t *event) {
     /* store it in the password array as UTF-8 */
     memcpy(password + input_position, buffer, n - 1);
     input_position += n - 1;
+    password[input_position] = '\0';
+    update_pam_visible_input();
     DEBUG("key accepted, input_position = %d\n", input_position);
 
     if (unlock_indicator) {

--- a/i3lock.c
+++ b/i3lock.c
@@ -212,6 +212,17 @@ static void clear_password_memory(void) {
 #endif
 }
 
+static void clear_pam_visible_input(void) {
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(pam_visible_input, sizeof(pam_visible_input));
+#else
+    volatile char *vinput = pam_visible_input;
+    for (size_t c = 0; c < sizeof(pam_visible_input); c++) {
+        vinput[c] = 0;
+    }
+#endif
+}
+
 ev_timer *start_timer(ev_timer *timer_obj, ev_tstamp timeout, ev_callback_t callback) {
     if (timer_obj) {
         ev_timer_stop(main_loop, timer_obj);
@@ -286,7 +297,7 @@ static void clear_input(void) {
     input_position = 0;
     clear_password_memory();
     password[input_position] = '\0';
-    pam_visible_input[0] = '\0';
+    clear_pam_visible_input();
 }
 
 static void discard_passwd_cb(EV_P_ ev_timer *w, int revents) {
@@ -321,13 +332,14 @@ static void auth_failed(void) {
 static void clear_pam_display_text(void) {
     pam_status_text[0] = '\0';
     pam_prompt_text[0] = '\0';
-    pam_visible_input[0] = '\0';
+    clear_pam_visible_input();
     pam_status_is_error = false;
     pam_prompt_echo_on = false;
     pam_status_expires_with_auth_wrong = false;
 }
 
 static void update_pam_visible_input(void) {
+    clear_pam_visible_input();
     if (pam_prompt_echo_on) {
         size_t len = strlen(password);
         if (len >= sizeof(pam_visible_input)) {
@@ -335,8 +347,6 @@ static void update_pam_visible_input(void) {
         }
         memcpy(pam_visible_input, password, len);
         pam_visible_input[len] = '\0';
-    } else {
-        pam_visible_input[0] = '\0';
     }
 }
 
@@ -364,7 +374,7 @@ static void handle_pam_event(const pam_event_t *event) {
             pam_waiting_for_prompt = true;
             snprintf(pam_prompt_text, sizeof(pam_prompt_text), "%s", event->text);
             pam_prompt_echo_on = event->echo_on;
-            pam_visible_input[0] = '\0';
+            clear_pam_visible_input();
             auth_state = STATE_AUTH_IDLE;
             unlock_state = STATE_KEY_PRESSED;
             clear_input();
@@ -485,7 +495,7 @@ static void input_done(void) {
         pam_waiting_for_prompt = false;
         active_pam_prompt_id = 0;
         pam_prompt_text[0] = '\0';
-        pam_visible_input[0] = '\0';
+        clear_pam_visible_input();
         pam_prompt_echo_on = false;
         auth_state = STATE_AUTH_VERIFY;
         if (!pam_controller_submit_answer(transaction_id, prompt_id, password)) {
@@ -1079,10 +1089,19 @@ static void xcb_check_cb(EV_P_ ev_check *w, int revents) {
 #ifndef __OpenBSD__
                 if (!controller_started) {
                     controller_started = true;
-                    pam_controller_init(saved_username, getenv("DISPLAY"));
                     pam_watcher = calloc(1, sizeof(struct ev_io));
                     if (pam_watcher == NULL) {
-                        errx(EXIT_FAILURE, "calloc pam_watcher");
+                        fprintf(stderr, "[i3lock] could not allocate PAM event watcher\n");
+                        auth_state = STATE_I3LOCK_LOCK_FAILED;
+                        redraw_screen();
+                        break;
+                    }
+                    if (!pam_controller_init(saved_username, getenv("DISPLAY"))) {
+                        free(pam_watcher);
+                        pam_watcher = NULL;
+                        auth_state = STATE_I3LOCK_LOCK_FAILED;
+                        redraw_screen();
+                        break;
                     }
                     ev_io_init(pam_watcher, pam_event_cb,
                                pam_controller_get_fd(), EV_READ);
@@ -1302,6 +1321,9 @@ int main(int argc, char *argv[]) {
      * be swapped to disk. Since Linux 2.6.9, this does not require any
      * privileges, just enough bytes in the RLIMIT_MEMLOCK limit. */
     if (mlock(password, sizeof(password)) != 0) {
+        err(EXIT_FAILURE, "Could not lock page in memory, check RLIMIT_MEMLOCK");
+    }
+    if (mlock(pam_visible_input, sizeof(pam_visible_input)) != 0) {
         err(EXIT_FAILURE, "Could not lock page in memory, check RLIMIT_MEMLOCK");
     }
 #endif

--- a/include/pam_controller.h
+++ b/include/pam_controller.h
@@ -1,0 +1,57 @@
+#ifndef _PAM_CONTROLLER_H
+#define _PAM_CONTROLLER_H
+
+#ifndef __OpenBSD__
+
+#include <stdint.h>
+
+typedef enum {
+    PAM_EVENT_AUTH_READY,
+    PAM_EVENT_AUTH_SUCCESS,
+    PAM_EVENT_AUTH_FAILURE,
+    PAM_EVENT_AUTH_FATAL,
+} pam_event_type_t;
+
+typedef struct {
+    pam_event_type_t type;
+    uint64_t transaction_id;
+    uint64_t prompt_id;
+} pam_event_t;
+
+/*
+ * Initialize the PAM controller: create worker thread, pipe, secure
+ * storage, and PAM handle.  Must be called exactly once, after all
+ * forks are complete.  Aborts on failure.
+ *
+ * username and display are copied internally.
+ */
+void pam_controller_init(const char *username, const char *display);
+
+/*
+ * Stage the password and start authentication.  The password is copied
+ * into mlocked storage; the caller should wipe its own copy afterward.
+ * Returns the transaction ID of the new authentication attempt, or 0 if
+ * the controller has not been initialized yet.
+ */
+uint64_t pam_controller_start_auth(const char *password);
+
+/*
+ * Returns the file descriptor that the main event loop should watch for
+ * readability.  When readable, call pam_controller_drain_events().
+ */
+int pam_controller_get_fd(void);
+
+/*
+ * Drain all pending events from the worker thread.  Calls the provided
+ * callback for each event.  Returns the number of events processed.
+ */
+int pam_controller_drain_events(void (*callback)(const pam_event_t *event));
+
+/*
+ * Shut down the controller: signal the worker to exit, join the thread,
+ * call pam_end, and free resources.
+ */
+void pam_controller_cleanup(void);
+
+#endif /* !__OpenBSD__ */
+#endif /* _PAM_CONTROLLER_H */

--- a/include/pam_controller.h
+++ b/include/pam_controller.h
@@ -5,10 +5,15 @@
 
 #include <stdint.h>
 
+#define PAM_EVENT_TEXT_MAX 256
+
 typedef enum {
     PAM_EVENT_AUTH_READY,
+    PAM_EVENT_AUTH_STATUS,
+    PAM_EVENT_AUTH_PROMPT,
     PAM_EVENT_AUTH_SUCCESS,
     PAM_EVENT_AUTH_FAILURE,
+    PAM_EVENT_AUTH_CANCELLED,
     PAM_EVENT_AUTH_FATAL,
 } pam_event_type_t;
 
@@ -16,6 +21,9 @@ typedef struct {
     pam_event_type_t type;
     uint64_t transaction_id;
     uint64_t prompt_id;
+    int echo_on;
+    int is_error;
+    char text[PAM_EVENT_TEXT_MAX];
 } pam_event_t;
 
 /*
@@ -34,6 +42,23 @@ void pam_controller_init(const char *username, const char *display);
  * the controller has not been initialized yet.
  */
 uint64_t pam_controller_start_auth(const char *password);
+
+/*
+ * Submit a response for the currently waiting prompt. Returns 1 when the
+ * answer was accepted by the controller, or 0 if the transaction/prompt no
+ * longer matches.
+ */
+int pam_controller_submit_answer(uint64_t transaction_id,
+                                 uint64_t prompt_id,
+                                 const char *answer);
+
+/*
+ * Request cancellation of an active transaction. If PAM is waiting inside
+ * the conversation callback, it is woken and the callback returns
+ * PAM_CONV_ERR. If PAM is doing backend work, the transaction is retired and
+ * the worker observes cancellation before the next prompt or terminal event.
+ */
+void pam_controller_cancel_auth(uint64_t transaction_id);
 
 /*
  * Returns the file descriptor that the main event loop should watch for

--- a/include/pam_controller.h
+++ b/include/pam_controller.h
@@ -27,9 +27,10 @@ typedef struct {
 } pam_event_t;
 
 /*
- * Initialize the PAM controller: create worker thread, pipe, secure
- * storage, and PAM handle.  Must be called exactly once, after all
- * forks are complete.  Aborts on failure.
+ * Initialize the PAM controller: create worker thread, pipe, and secure
+ * storage. PAM handles are created fresh for each authentication attempt.
+ * Must be called exactly once, after all forks are complete. Returns 1 on
+ * success and 0 on failure; failures must leave i3lock locked.
  *
  * username and display are copied internally.
  */
@@ -39,7 +40,7 @@ int pam_controller_init(const char *username, const char *display);
  * Stage the password and start authentication.  The password is copied
  * into mlocked storage; the caller should wipe its own copy afterward.
  * Returns the transaction ID of the new authentication attempt, or 0 if
- * the controller has not been initialized yet.
+ * the controller is not ready to accept a fresh attempt.
  */
 uint64_t pam_controller_start_auth(const char *password);
 
@@ -59,6 +60,13 @@ int pam_controller_submit_answer(uint64_t transaction_id,
  * the worker observes cancellation before the next prompt or terminal event.
  */
 void pam_controller_cancel_auth(uint64_t transaction_id);
+
+/*
+ * Acknowledge that the UI has consumed and committed a terminal event for
+ * a transaction. Until this happens, the controller will not accept another
+ * authentication attempt for that transaction slot.
+ */
+void pam_controller_ack_terminal(uint64_t transaction_id);
 
 /*
  * Returns the file descriptor that the main event loop should watch for

--- a/include/pam_controller.h
+++ b/include/pam_controller.h
@@ -33,7 +33,7 @@ typedef struct {
  *
  * username and display are copied internally.
  */
-void pam_controller_init(const char *username, const char *display);
+int pam_controller_init(const char *username, const char *display);
 
 /*
  * Stage the password and start authentication.  The password is copied

--- a/include/unlock_indicator.h
+++ b/include/unlock_indicator.h
@@ -3,6 +3,9 @@
 
 #include <xcb/xcb.h>
 
+#define I3LOCK_PAM_UI_TEXT_MAX 256
+#define I3LOCK_PAM_VISIBLE_INPUT_MAX 256
+
 typedef enum {
     STATE_STARTED = 0,           /* default state */
     STATE_KEY_PRESSED = 1,       /* key was pressed, show unlock indicator */

--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,7 @@ i3lock_deps = [
 host_os = host_machine.system()
 if host_os != 'openbsd'
   pam_dep = cc.find_library('pam', required: true)
+  i3lock_srcs += ['pam_controller.c']
   i3lock_deps += [pam_dep]
 endif
 

--- a/pam_controller.c
+++ b/pam_controller.c
@@ -1,8 +1,9 @@
 /*
  * Fork-safe PAM controller for i3lock.
  *
- * The controller owns a dedicated worker thread that holds the PAM
- * handle and runs pam_authenticate, pam_setcred, and pam_end. The
+ * The controller owns a dedicated worker thread that creates a fresh PAM
+ * handle per authentication attempt and runs pam_authenticate,
+ * pam_acct_mgmt, pam_setcred, and pam_end. The
  * main thread communicates with the worker through a mutex-protected
  * command slot and receives results through an event queue drained via
  * a libev-watched pipe.
@@ -36,6 +37,7 @@
 
 #define MAX_EVENTS 16
 #define SECURE_BUFFER_SIZE 512
+#define PAM_MESSAGE_INPUT_MAX 4096
 
 /* secure wiping */
 
@@ -81,6 +83,7 @@ static struct {
     bool waiting_for_answer;
     bool answer_submitted;
     bool fatal_error;
+    bool terminal_ack_pending;
     bool pipe_created;
     bool secure_mlocked;
     bool mutex_initialised;
@@ -90,11 +93,11 @@ static struct {
     uint64_t next_transaction_id;
     uint64_t next_prompt_id;
     uint64_t active_transaction_id;
+    uint64_t terminal_transaction_id;
     uint64_t waiting_prompt_id;
     int prompts_seen;
 
-    /* PAM handle: exclusively owned by the worker. */
-    pam_handle_t *pam_handle;
+    /* PAM conversation structure: passed to every per-attempt handle. */
     struct pam_conv pam_conv;
 
     /* Initialisation parameters (copied). */
@@ -111,18 +114,60 @@ static struct {
 
 /* Post an event and wake the main event loop. Must be called with
  * ctrl.mutex held. */
-static void post_event_locked(pam_event_t event) {
+static bool event_is_terminal(pam_event_type_t type) {
+    return type == PAM_EVENT_AUTH_SUCCESS ||
+           type == PAM_EVENT_AUTH_FAILURE ||
+           type == PAM_EVENT_AUTH_CANCELLED ||
+           type == PAM_EVENT_AUTH_FATAL;
+}
+
+static void remove_event_at_locked(int index) {
+    if (index < 0 || index >= ctrl.event_count) {
+        return;
+    }
+    if (index < ctrl.event_count - 1) {
+        memmove(ctrl.events + index,
+                ctrl.events + index + 1,
+                (size_t)(ctrl.event_count - index - 1) * sizeof(ctrl.events[0]));
+    }
+    ctrl.event_count--;
+}
+
+static bool post_event_locked(pam_event_t event) {
     if (ctrl.event_count < MAX_EVENTS) {
         ctrl.events[ctrl.event_count++] = event;
     } else {
-        memmove(ctrl.events, ctrl.events + 1, (MAX_EVENTS - 1) * sizeof(ctrl.events[0]));
-        ctrl.events[MAX_EVENTS - 1] = event;
+        int drop_index = -1;
+        for (int i = 0; i < ctrl.event_count; i++) {
+            if (ctrl.events[i].type == PAM_EVENT_AUTH_STATUS) {
+                drop_index = i;
+                break;
+            }
+        }
+        if (drop_index == -1 && event_is_terminal(event.type)) {
+            for (int i = 0; i < ctrl.event_count; i++) {
+                if (!event_is_terminal(ctrl.events[i].type)) {
+                    drop_index = i;
+                    break;
+                }
+            }
+        }
+        if (drop_index == -1) {
+            if (event_is_terminal(event.type)) {
+                drop_index = 0;
+            } else {
+                return event.type == PAM_EVENT_AUTH_STATUS;
+            }
+        }
+        remove_event_at_locked(drop_index);
+        ctrl.events[ctrl.event_count++] = event;
     }
     char byte = 0;
     ssize_t written;
     do {
         written = write(ctrl.pipe_fds[1], &byte, 1);
     } while (written == -1 && errno == EINTR);
+    return true;
 }
 
 static void free_replies(struct pam_response *reply, int count) {
@@ -144,6 +189,13 @@ static int copy_secure_value_to_response(char **response, const char *value) {
         return PAM_BUF_ERR;
     }
     return PAM_SUCCESS;
+}
+
+static bool pam_message_text_is_valid(const char *text) {
+    if (text == NULL) {
+        return true;
+    }
+    return strnlen(text, PAM_MESSAGE_INPUT_MAX) < PAM_MESSAGE_INPUT_MAX;
 }
 
 static void event_set_text(pam_event_t *event, const char *text) {
@@ -184,6 +236,14 @@ static void end_pam_handle(pam_handle_t *handle, int status) {
     if (handle != NULL) {
         pam_end(handle, status);
     }
+}
+
+static bool cancellation_requested_locked_read(void) {
+    bool cancelled;
+    pthread_mutex_lock(&ctrl.mutex);
+    cancelled = ctrl.cancellation_requested || ctrl.shutdown_requested;
+    pthread_mutex_unlock(&ctrl.mutex);
+    return cancelled;
 }
 
 static void reset_controller_init_state(void) {
@@ -228,7 +288,7 @@ static int worker_conv_callback(int num_msg,
     *resp = NULL;
 
     for (int i = 0; i < num_msg; i++) {
-        if (msg[i] == NULL) {
+        if (msg[i] == NULL || !pam_message_text_is_valid(msg[i]->msg)) {
             return PAM_CONV_ERR;
         }
     }
@@ -278,7 +338,14 @@ static int worker_conv_callback(int num_msg,
                 .echo_on = style == PAM_PROMPT_ECHO_ON,
             };
             event_set_text(&event, msg[i]->msg);
-            post_event_locked(event);
+            if (!post_event_locked(event)) {
+                ctrl.waiting_for_answer = false;
+                ctrl.answer_submitted = false;
+                ctrl.waiting_prompt_id = 0;
+                pthread_mutex_unlock(&ctrl.mutex);
+                free_replies(reply, num_msg);
+                return PAM_CONV_ERR;
+            }
 
             while (!ctrl.answer_submitted &&
                    !ctrl.cancellation_requested &&
@@ -317,7 +384,7 @@ static int worker_conv_callback(int num_msg,
                 .is_error = style == PAM_ERROR_MSG,
             };
             event_set_text(&event, msg[i]->msg);
-            post_event_locked(event);
+            (void)post_event_locked(event);
         } else {
             pthread_mutex_unlock(&ctrl.mutex);
             free_replies(reply, num_msg);
@@ -336,22 +403,9 @@ static int worker_conv_callback(int num_msg,
 static void *worker_main(void *arg) {
     (void)arg;
 
-    /* Initialise the PAM handle. The worker owns it exclusively. */
     pam_handle_t *handle = NULL;
-    int ret = start_pam_handle(&handle);
-    if (ret != PAM_SUCCESS) {
-        pthread_mutex_lock(&ctrl.mutex);
-        post_event_locked((pam_event_t){
-            .type = PAM_EVENT_AUTH_FATAL,
-            .transaction_id = 0,
-            .prompt_id = 0,
-        });
-        pthread_mutex_unlock(&ctrl.mutex);
-        return NULL;
-    }
 
     pthread_mutex_lock(&ctrl.mutex);
-    ctrl.pam_handle = handle;
     post_event_locked((pam_event_t){
         .type = PAM_EVENT_AUTH_READY,
         .transaction_id = 0,
@@ -374,11 +428,31 @@ static void *worker_main(void *arg) {
         ctrl.waiting_prompt_id = 0;
         ctrl.prompts_seen = 0;
         uint64_t txn = ctrl.active_transaction_id;
-        handle = ctrl.pam_handle;
         pthread_mutex_unlock(&ctrl.mutex);
 
-        /* pam_authenticate blocks and invokes worker_conv_callback. */
-        ret = pam_authenticate(handle, 0);
+        int ret = start_pam_handle(&handle);
+        int terminal_status = ret;
+        if (ret == PAM_SUCCESS) {
+            /* pam_authenticate blocks and invokes worker_conv_callback. */
+            ret = pam_authenticate(handle, 0);
+            terminal_status = ret;
+        }
+
+        if (ret == PAM_SUCCESS && !cancellation_requested_locked_read()) {
+            ret = pam_acct_mgmt(handle, 0);
+            terminal_status = ret;
+        }
+
+        if (ret == PAM_SUCCESS && !cancellation_requested_locked_read()) {
+            ret = pam_setcred(handle, PAM_REFRESH_CRED);
+            terminal_status = ret;
+        }
+
+        if (cancellation_requested_locked_read()) {
+            terminal_status = PAM_CONV_ERR;
+        }
+        end_pam_handle(handle, terminal_status);
+        handle = NULL;
 
         pthread_mutex_lock(&ctrl.mutex);
         secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
@@ -388,44 +462,18 @@ static void *worker_main(void *arg) {
         ctrl.waiting_prompt_id = 0;
         if (ctrl.cancellation_requested) {
             ctrl.cancellation_requested = false;
-            post_event_locked((pam_event_t){
+            ctrl.terminal_ack_pending = true;
+            ctrl.terminal_transaction_id = txn;
+            (void)post_event_locked((pam_event_t){
                 .type = PAM_EVENT_AUTH_CANCELLED,
                 .transaction_id = txn,
                 .prompt_id = 0,
                 .echo_on = 0,
             });
-            ctrl.pam_handle = NULL;
-            pthread_mutex_unlock(&ctrl.mutex);
-            end_pam_handle(handle, ret);
-            handle = NULL;
-            ret = start_pam_handle(&handle);
-            pthread_mutex_lock(&ctrl.mutex);
-            if (ret == PAM_SUCCESS) {
-                ctrl.pam_handle = handle;
-                post_event_locked((pam_event_t){
-                    .type = PAM_EVENT_AUTH_READY,
-                    .transaction_id = 0,
-                    .prompt_id = 0,
-                    .echo_on = 0,
-                });
-            } else {
-                pam_event_t fatal = {
-                    .type = PAM_EVENT_AUTH_FATAL,
-                    .transaction_id = 0,
-                    .prompt_id = 0,
-                    .echo_on = 0,
-                    .is_error = 1,
-                };
-                event_set_text(&fatal, "Authentication service failed");
-                ctrl.fatal_error = true;
-                post_event_locked(fatal);
-            }
         } else if (ret == PAM_SUCCESS) {
-            /* Refresh credentials (Kerberos tickets, etc.).
-             * Do not downgrade a successful authentication if
-             * credential refresh fails. */
-            pam_setcred(handle, PAM_REFRESH_CRED);
-            post_event_locked((pam_event_t){
+            ctrl.terminal_ack_pending = true;
+            ctrl.terminal_transaction_id = txn;
+            (void)post_event_locked((pam_event_t){
                 .type = PAM_EVENT_AUTH_SUCCESS,
                 .transaction_id = txn,
                 .prompt_id = 0,
@@ -441,11 +489,9 @@ static void *worker_main(void *arg) {
             };
             event_set_text(&event, "Authentication service failed");
             ctrl.fatal_error = true;
-            post_event_locked(event);
-            ctrl.pam_handle = NULL;
-            pthread_mutex_unlock(&ctrl.mutex);
-            end_pam_handle(handle, ret);
-            pthread_mutex_lock(&ctrl.mutex);
+            ctrl.terminal_ack_pending = true;
+            ctrl.terminal_transaction_id = txn;
+            (void)post_event_locked(event);
         } else if (ret == PAM_SYSTEM_ERR || ret == PAM_SERVICE_ERR) {
             pam_event_t event = {
                 .type = PAM_EVENT_AUTH_FAILURE,
@@ -455,49 +501,29 @@ static void *worker_main(void *arg) {
                 .is_error = 1,
             };
             event_set_text(&event, "Authentication service error");
-            post_event_locked(event);
-            ctrl.pam_handle = NULL;
-
-            pthread_mutex_unlock(&ctrl.mutex);
-            end_pam_handle(handle, ret);
-            handle = NULL;
-            ret = start_pam_handle(&handle);
-            pthread_mutex_lock(&ctrl.mutex);
-            if (ret == PAM_SUCCESS) {
-                ctrl.pam_handle = handle;
-                post_event_locked((pam_event_t){
-                    .type = PAM_EVENT_AUTH_READY,
-                    .transaction_id = 0,
-                    .prompt_id = 0,
-                    .echo_on = 0,
-                });
-            } else {
-                pam_event_t fatal = {
-                    .type = PAM_EVENT_AUTH_FATAL,
-                    .transaction_id = 0,
-                    .prompt_id = 0,
-                    .echo_on = 0,
-                    .is_error = 1,
-                };
-                event_set_text(&fatal, "Authentication service failed");
-                ctrl.fatal_error = true;
-                post_event_locked(fatal);
-            }
+            ctrl.terminal_ack_pending = true;
+            ctrl.terminal_transaction_id = txn;
+            (void)post_event_locked(event);
         } else {
-            post_event_locked((pam_event_t){
+            ctrl.terminal_ack_pending = true;
+            ctrl.terminal_transaction_id = txn;
+            (void)post_event_locked((pam_event_t){
                 .type = PAM_EVENT_AUTH_FAILURE,
                 .transaction_id = txn,
                 .prompt_id = 0,
                 .echo_on = 0,
             });
         }
-        ctrl.auth_in_progress = false;
+
+        while (ctrl.terminal_ack_pending && !ctrl.shutdown_requested) {
+            pthread_cond_wait(&ctrl.cond, &ctrl.mutex);
+        }
+        if (!ctrl.shutdown_requested) {
+            ctrl.auth_in_progress = false;
+        }
     }
-    handle = ctrl.pam_handle;
-    ctrl.pam_handle = NULL;
     pthread_mutex_unlock(&ctrl.mutex);
 
-    end_pam_handle(handle, PAM_SUCCESS);
     return NULL;
 }
 
@@ -605,7 +631,7 @@ uint64_t pam_controller_start_auth(const char *password) {
         ctrl.auth_in_progress ||
         ctrl.shutdown_requested ||
         ctrl.fatal_error ||
-        ctrl.pam_handle == NULL) {
+        ctrl.terminal_ack_pending) {
         pthread_mutex_unlock(&ctrl.mutex);
         return 0;
     }
@@ -669,12 +695,35 @@ void pam_controller_cancel_auth(uint64_t transaction_id) {
     }
 
     pthread_mutex_lock(&ctrl.mutex);
+    if (ctrl.terminal_ack_pending &&
+        ctrl.terminal_transaction_id == transaction_id) {
+        ctrl.terminal_ack_pending = false;
+        ctrl.terminal_transaction_id = 0;
+        ctrl.auth_in_progress = false;
+        pthread_cond_signal(&ctrl.cond);
+    }
     if (ctrl.active_transaction_id == transaction_id &&
         (ctrl.auth_requested || ctrl.auth_in_progress)) {
         ctrl.cancellation_requested = true;
         ctrl.auth_requested = false;
         secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
         secure_wipe(ctrl.secure->pending_response, SECURE_BUFFER_SIZE);
+        pthread_cond_signal(&ctrl.cond);
+    }
+    pthread_mutex_unlock(&ctrl.mutex);
+}
+
+void pam_controller_ack_terminal(uint64_t transaction_id) {
+    if (!ctrl.initialised) {
+        return;
+    }
+
+    pthread_mutex_lock(&ctrl.mutex);
+    if (ctrl.terminal_ack_pending &&
+        ctrl.terminal_transaction_id == transaction_id) {
+        ctrl.terminal_ack_pending = false;
+        ctrl.terminal_transaction_id = 0;
+        ctrl.auth_in_progress = false;
         pthread_cond_signal(&ctrl.cond);
     }
     pthread_mutex_unlock(&ctrl.mutex);

--- a/pam_controller.c
+++ b/pam_controller.c
@@ -80,6 +80,10 @@ static struct {
     bool waiting_for_answer;
     bool answer_submitted;
     bool fatal_error;
+    bool pipe_created;
+    bool secure_mlocked;
+    bool mutex_initialised;
+    bool cond_initialised;
 
     /* Transaction tracking. */
     uint64_t next_transaction_id;
@@ -110,11 +114,8 @@ static void post_event_locked(pam_event_t event) {
     if (ctrl.event_count < MAX_EVENTS) {
         ctrl.events[ctrl.event_count++] = event;
     } else {
-        ctrl.events[MAX_EVENTS - 1] = (pam_event_t){
-            .type = PAM_EVENT_AUTH_FATAL,
-            .transaction_id = event.transaction_id,
-            .prompt_id = event.prompt_id,
-        };
+        memmove(ctrl.events, ctrl.events + 1, (MAX_EVENTS - 1) * sizeof(ctrl.events[0]));
+        ctrl.events[MAX_EVENTS - 1] = event;
     }
     char byte = 0;
     (void)write(ctrl.pipe_fds[1], &byte, 1);
@@ -154,21 +155,20 @@ static int worker_conv_callback(int num_msg,
                                 struct pam_response **resp,
                                 void *appdata_ptr);
 
-static int start_pam_handle(void) {
-    ctrl.pam_conv = (struct pam_conv){worker_conv_callback, NULL};
-    int ret = pam_start("i3lock", ctrl.username, &ctrl.pam_conv, &ctrl.pam_handle);
+static int start_pam_handle(pam_handle_t **handle) {
+    *handle = NULL;
+    int ret = pam_start("i3lock", ctrl.username, &ctrl.pam_conv, handle);
     if (ret != PAM_SUCCESS) {
         fprintf(stderr, "[i3lock] PAM worker: pam_start failed (%d)\n", ret);
-        ctrl.pam_handle = NULL;
         return ret;
     }
 
     if (ctrl.display != NULL) {
-        ret = pam_set_item(ctrl.pam_handle, PAM_TTY, ctrl.display);
+        ret = pam_set_item(*handle, PAM_TTY, ctrl.display);
         if (ret != PAM_SUCCESS) {
             fprintf(stderr, "[i3lock] PAM worker: pam_set_item(PAM_TTY) failed (%d)\n", ret);
-            pam_end(ctrl.pam_handle, ret);
-            ctrl.pam_handle = NULL;
+            pam_end(*handle, ret);
+            *handle = NULL;
             return ret;
         }
     }
@@ -176,11 +176,35 @@ static int start_pam_handle(void) {
     return PAM_SUCCESS;
 }
 
-static void end_pam_handle(int status) {
-    if (ctrl.pam_handle != NULL) {
-        pam_end(ctrl.pam_handle, status);
-        ctrl.pam_handle = NULL;
+static void end_pam_handle(pam_handle_t *handle, int status) {
+    if (handle != NULL) {
+        pam_end(handle, status);
     }
+}
+
+static void reset_controller_init_state(void) {
+    if (ctrl.secure != NULL) {
+        secure_wipe(ctrl.secure, sizeof(*ctrl.secure));
+#if defined(__linux__)
+        if (ctrl.secure_mlocked) {
+            munlock(ctrl.secure, sizeof(*ctrl.secure));
+        }
+#endif
+        free(ctrl.secure);
+    }
+    if (ctrl.pipe_created) {
+        close(ctrl.pipe_fds[0]);
+        close(ctrl.pipe_fds[1]);
+    }
+    if (ctrl.cond_initialised) {
+        pthread_cond_destroy(&ctrl.cond);
+    }
+    if (ctrl.mutex_initialised) {
+        pthread_mutex_destroy(&ctrl.mutex);
+    }
+    free(ctrl.username);
+    free(ctrl.display);
+    memset(&ctrl, 0, sizeof(ctrl));
 }
 
 /* pam_conv callback, running in the worker thread */
@@ -299,7 +323,8 @@ static void *worker_main(void *arg) {
     (void)arg;
 
     /* Initialise the PAM handle. The worker owns it exclusively. */
-    int ret = start_pam_handle();
+    pam_handle_t *handle = NULL;
+    int ret = start_pam_handle(&handle);
     if (ret != PAM_SUCCESS) {
         pthread_mutex_lock(&ctrl.mutex);
         post_event_locked((pam_event_t){
@@ -312,6 +337,7 @@ static void *worker_main(void *arg) {
     }
 
     pthread_mutex_lock(&ctrl.mutex);
+    ctrl.pam_handle = handle;
     post_event_locked((pam_event_t){
         .type = PAM_EVENT_AUTH_READY,
         .transaction_id = 0,
@@ -334,15 +360,15 @@ static void *worker_main(void *arg) {
         ctrl.waiting_prompt_id = 0;
         ctrl.prompts_seen = 0;
         uint64_t txn = ctrl.active_transaction_id;
+        handle = ctrl.pam_handle;
         pthread_mutex_unlock(&ctrl.mutex);
 
         /* pam_authenticate blocks and invokes worker_conv_callback. */
-        ret = pam_authenticate(ctrl.pam_handle, 0);
+        ret = pam_authenticate(handle, 0);
 
         pthread_mutex_lock(&ctrl.mutex);
         secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
         secure_wipe(ctrl.secure->pending_response, SECURE_BUFFER_SIZE);
-        ctrl.auth_in_progress = false;
         ctrl.waiting_for_answer = false;
         ctrl.answer_submitted = false;
         ctrl.waiting_prompt_id = 0;
@@ -358,7 +384,7 @@ static void *worker_main(void *arg) {
             /* Refresh credentials (Kerberos tickets, etc.).
              * Do not downgrade a successful authentication if
              * credential refresh fails. */
-            pam_setcred(ctrl.pam_handle, PAM_REFRESH_CRED);
+            pam_setcred(handle, PAM_REFRESH_CRED);
             post_event_locked((pam_event_t){
                 .type = PAM_EVENT_AUTH_SUCCESS,
                 .transaction_id = txn,
@@ -376,8 +402,9 @@ static void *worker_main(void *arg) {
             event_set_text(&event, "Authentication service failed");
             ctrl.fatal_error = true;
             post_event_locked(event);
+            ctrl.pam_handle = NULL;
             pthread_mutex_unlock(&ctrl.mutex);
-            end_pam_handle(ret);
+            end_pam_handle(handle, ret);
             pthread_mutex_lock(&ctrl.mutex);
         } else if (ret == PAM_SYSTEM_ERR || ret == PAM_SERVICE_ERR) {
             pam_event_t event = {
@@ -389,12 +416,15 @@ static void *worker_main(void *arg) {
             };
             event_set_text(&event, "Authentication service error");
             post_event_locked(event);
+            ctrl.pam_handle = NULL;
 
             pthread_mutex_unlock(&ctrl.mutex);
-            end_pam_handle(ret);
-            ret = start_pam_handle();
+            end_pam_handle(handle, ret);
+            handle = NULL;
+            ret = start_pam_handle(&handle);
             pthread_mutex_lock(&ctrl.mutex);
             if (ret == PAM_SUCCESS) {
+                ctrl.pam_handle = handle;
                 post_event_locked((pam_event_t){
                     .type = PAM_EVENT_AUTH_READY,
                     .transaction_id = 0,
@@ -421,31 +451,36 @@ static void *worker_main(void *arg) {
                 .echo_on = 0,
             });
         }
+        ctrl.auth_in_progress = false;
     }
+    handle = ctrl.pam_handle;
+    ctrl.pam_handle = NULL;
     pthread_mutex_unlock(&ctrl.mutex);
 
-    end_pam_handle(PAM_SUCCESS);
+    end_pam_handle(handle, PAM_SUCCESS);
     return NULL;
 }
 
 /* public API */
 
-void pam_controller_init(const char *username, const char *display) {
+int pam_controller_init(const char *username, const char *display) {
     if (ctrl.initialised) {
-        return;
+        return 1;
     }
 
     /* Copy configuration strings. */
     ctrl.username = strdup(username);
     if (ctrl.username == NULL) {
         perror("strdup");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
     if (display != NULL) {
         ctrl.display = strdup(display);
         if (ctrl.display == NULL) {
             perror("strdup");
-            exit(EXIT_FAILURE);
+            reset_controller_init_state();
+            return 0;
         }
     }
 
@@ -453,48 +488,65 @@ void pam_controller_init(const char *username, const char *display) {
     ctrl.secure = calloc(1, sizeof(*ctrl.secure));
     if (ctrl.secure == NULL) {
         perror("calloc");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
 #if defined(__linux__)
     if (mlock(ctrl.secure, sizeof(*ctrl.secure)) != 0) {
         perror("mlock(secure storage)");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
+    ctrl.secure_mlocked = true;
 #endif
 
     /* Create the wake-up pipe. The read end is non-blocking so that
      * drain_events never stalls the event loop. */
     if (pipe(ctrl.pipe_fds) != 0) {
         perror("pipe");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
+    ctrl.pipe_created = true;
     int flags = fcntl(ctrl.pipe_fds[0], F_GETFL);
     if (flags == -1 || fcntl(ctrl.pipe_fds[0], F_SETFL, flags | O_NONBLOCK) == -1) {
         perror("fcntl(O_NONBLOCK)");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
     flags = fcntl(ctrl.pipe_fds[1], F_GETFL);
     if (flags == -1 || fcntl(ctrl.pipe_fds[1], F_SETFL, flags | O_NONBLOCK) == -1) {
         perror("fcntl(O_NONBLOCK)");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
 
     /* Initialise synchronisation primitives. */
-    if (pthread_mutex_init(&ctrl.mutex, NULL) != 0 ||
-        pthread_cond_init(&ctrl.cond, NULL) != 0) {
-        fprintf(stderr, "[i3lock] could not initialise mutex/condvar\n");
-        exit(EXIT_FAILURE);
+    if (pthread_mutex_init(&ctrl.mutex, NULL) != 0) {
+        fprintf(stderr, "[i3lock] could not initialise mutex\n");
+        reset_controller_init_state();
+        return 0;
     }
+    ctrl.mutex_initialised = true;
+    if (pthread_cond_init(&ctrl.cond, NULL) != 0) {
+        fprintf(stderr, "[i3lock] could not initialise condvar\n");
+        reset_controller_init_state();
+        return 0;
+    }
+    ctrl.cond_initialised = true;
 
     ctrl.next_transaction_id = 1;
     ctrl.next_prompt_id = 1;
-    ctrl.initialised = true;
+    ctrl.pam_conv = (struct pam_conv){worker_conv_callback, NULL};
 
     /* Start the worker thread. */
     if (pthread_create(&ctrl.worker, NULL, worker_main, NULL) != 0) {
         perror("pthread_create");
-        exit(EXIT_FAILURE);
+        reset_controller_init_state();
+        return 0;
     }
+    ctrl.initialised = true;
+    return 1;
 }
 
 uint64_t pam_controller_start_auth(const char *password) {
@@ -506,7 +558,8 @@ uint64_t pam_controller_start_auth(const char *password) {
     if (ctrl.auth_requested ||
         ctrl.auth_in_progress ||
         ctrl.shutdown_requested ||
-        ctrl.fatal_error) {
+        ctrl.fatal_error ||
+        ctrl.pam_handle == NULL) {
         pthread_mutex_unlock(&ctrl.mutex);
         return 0;
     }

--- a/pam_controller.c
+++ b/pam_controller.c
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <security/pam_appl.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -118,7 +119,10 @@ static void post_event_locked(pam_event_t event) {
         ctrl.events[MAX_EVENTS - 1] = event;
     }
     char byte = 0;
-    (void)write(ctrl.pipe_fds[1], &byte, 1);
+    ssize_t written;
+    do {
+        written = write(ctrl.pipe_fds[1], &byte, 1);
+    } while (written == -1 && errno == EINTR);
 }
 
 static void free_replies(struct pam_response *reply, int count) {
@@ -215,8 +219,18 @@ static int worker_conv_callback(int num_msg,
                                 void *appdata_ptr) {
     (void)appdata_ptr;
 
-    if (num_msg <= 0) {
+    if (num_msg <= 0 ||
+        num_msg > PAM_MAX_NUM_MSG ||
+        msg == NULL ||
+        resp == NULL) {
         return PAM_CONV_ERR;
+    }
+    *resp = NULL;
+
+    for (int i = 0; i < num_msg; i++) {
+        if (msg[i] == NULL) {
+            return PAM_CONV_ERR;
+        }
     }
 
     struct pam_response *reply = calloc((size_t)num_msg, sizeof(*reply));
@@ -380,6 +394,32 @@ static void *worker_main(void *arg) {
                 .prompt_id = 0,
                 .echo_on = 0,
             });
+            ctrl.pam_handle = NULL;
+            pthread_mutex_unlock(&ctrl.mutex);
+            end_pam_handle(handle, ret);
+            handle = NULL;
+            ret = start_pam_handle(&handle);
+            pthread_mutex_lock(&ctrl.mutex);
+            if (ret == PAM_SUCCESS) {
+                ctrl.pam_handle = handle;
+                post_event_locked((pam_event_t){
+                    .type = PAM_EVENT_AUTH_READY,
+                    .transaction_id = 0,
+                    .prompt_id = 0,
+                    .echo_on = 0,
+                });
+            } else {
+                pam_event_t fatal = {
+                    .type = PAM_EVENT_AUTH_FATAL,
+                    .transaction_id = 0,
+                    .prompt_id = 0,
+                    .echo_on = 0,
+                    .is_error = 1,
+                };
+                event_set_text(&fatal, "Authentication service failed");
+                ctrl.fatal_error = true;
+                post_event_locked(fatal);
+            }
         } else if (ret == PAM_SUCCESS) {
             /* Refresh credentials (Kerberos tickets, etc.).
              * Do not downgrade a successful authentication if
@@ -391,7 +431,7 @@ static void *worker_main(void *arg) {
                 .prompt_id = 0,
                 .echo_on = 0,
             });
-        } else if (ret == PAM_ABORT) {
+        } else if (ret == PAM_ABORT || ret == PAM_MAXTRIES) {
             pam_event_t event = {
                 .type = PAM_EVENT_AUTH_FATAL,
                 .transaction_id = txn,
@@ -538,6 +578,12 @@ int pam_controller_init(const char *username, const char *display) {
     ctrl.next_transaction_id = 1;
     ctrl.next_prompt_id = 1;
     ctrl.pam_conv = (struct pam_conv){worker_conv_callback, NULL};
+
+    struct sigaction action = {
+        .sa_handler = SIG_IGN,
+    };
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGPIPE, &action, NULL);
 
     /* Start the worker thread. */
     if (pthread_create(&ctrl.worker, NULL, worker_main, NULL) != 0) {

--- a/pam_controller.c
+++ b/pam_controller.c
@@ -8,9 +8,9 @@
  * a libev-watched pipe.
  *
  * Credential copies owned by the controller live in a single mlock()ed
- * region. The foundation preserves legacy i3lock conversation semantics
- * during one PAM transaction and wipes the staged input when
- * pam_authenticate returns or the controller shuts down.
+ * region. The worker returns a credential to PAM only after ownership has
+ * transferred to the pam_response array, then immediately wipes the
+ * controller-owned copy.
  */
 
 #include <config.h>
@@ -76,11 +76,16 @@ static struct {
     bool auth_requested;
     bool auth_in_progress;
     bool shutdown_requested;
+    bool cancellation_requested;
+    bool waiting_for_answer;
+    bool answer_submitted;
 
     /* Transaction tracking. */
     uint64_t next_transaction_id;
     uint64_t next_prompt_id;
     uint64_t active_transaction_id;
+    uint64_t waiting_prompt_id;
+    int prompts_seen;
 
     /* PAM handle: exclusively owned by the worker. */
     pam_handle_t *pam_handle;
@@ -113,18 +118,37 @@ static void post_event_locked(pam_event_t event) {
     (void)write(ctrl.pipe_fds[1], &byte, 1);
 }
 
+static void free_replies(struct pam_response *reply, int count) {
+    if (reply == NULL) {
+        return;
+    }
+    for (int i = 0; i < count; i++) {
+        if (reply[i].resp != NULL) {
+            secure_wipe(reply[i].resp, strlen(reply[i].resp));
+            free(reply[i].resp);
+        }
+    }
+    free(reply);
+}
+
+static int copy_secure_value_to_response(char **response, const char *value) {
+    *response = strdup(value);
+    if (*response == NULL) {
+        return PAM_BUF_ERR;
+    }
+    return PAM_SUCCESS;
+}
+
+static void event_set_text(pam_event_t *event, const char *text) {
+    if (text == NULL) {
+        event->text[0] = '\0';
+        return;
+    }
+    snprintf(event->text, sizeof(event->text), "%s", text);
+}
+
 /* pam_conv callback, running in the worker thread */
 
-/*
- * Foundation-stage behaviour: every prompt in this callback batch
- * receives the deferred input that was staged by the main thread before
- * authentication started. INFO and ERROR messages receive a NULL
- * response.
- *
- * Note: uses (*resp)[i] (correct array indexing), not the resp[i]
- * pattern in the original conv_callback, which is a wild pointer
- * dereference when i is greater than zero.
- */
 static int worker_conv_callback(int num_msg,
                                 const struct pam_message **msg,
                                 struct pam_response **resp,
@@ -142,21 +166,88 @@ static int worker_conv_callback(int num_msg,
 
     pthread_mutex_lock(&ctrl.mutex);
     for (int i = 0; i < num_msg; i++) {
+        if (ctrl.shutdown_requested || ctrl.cancellation_requested) {
+            pthread_mutex_unlock(&ctrl.mutex);
+            free_replies(reply, num_msg);
+            return PAM_CONV_ERR;
+        }
+
         int style = msg[i]->msg_style;
         if (style == PAM_PROMPT_ECHO_OFF || style == PAM_PROMPT_ECHO_ON) {
-            reply[i].resp = strdup(ctrl.secure->deferred_input);
-            reply[i].resp_retcode = 0;
-            if (reply[i].resp == NULL) {
-                pthread_mutex_unlock(&ctrl.mutex);
-                for (int j = 0; j < i; j++) {
-                    if (reply[j].resp != NULL) {
-                        secure_wipe(reply[j].resp, strlen(reply[j].resp));
-                        free(reply[j].resp);
-                    }
+            ctrl.prompts_seen++;
+            bool use_deferred = ctrl.prompts_seen == 1 &&
+                                style == PAM_PROMPT_ECHO_OFF &&
+                                ctrl.secure->deferred_input[0] != '\0';
+
+            if (use_deferred) {
+                int result = copy_secure_value_to_response(&reply[i].resp,
+                                                           ctrl.secure->deferred_input);
+                secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
+                if (result != PAM_SUCCESS) {
+                    pthread_mutex_unlock(&ctrl.mutex);
+                    free_replies(reply, num_msg);
+                    return result;
                 }
-                free(reply);
-                return PAM_BUF_ERR;
+                reply[i].resp_retcode = 0;
+                continue;
             }
+
+            secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
+            uint64_t prompt_id = ctrl.next_prompt_id++;
+            ctrl.waiting_prompt_id = prompt_id;
+            ctrl.waiting_for_answer = true;
+            ctrl.answer_submitted = false;
+            pam_event_t event = {
+                .type = PAM_EVENT_AUTH_PROMPT,
+                .transaction_id = ctrl.active_transaction_id,
+                .prompt_id = prompt_id,
+                .echo_on = style == PAM_PROMPT_ECHO_ON,
+            };
+            event_set_text(&event, msg[i]->msg);
+            post_event_locked(event);
+
+            while (!ctrl.answer_submitted &&
+                   !ctrl.cancellation_requested &&
+                   !ctrl.shutdown_requested) {
+                pthread_cond_wait(&ctrl.cond, &ctrl.mutex);
+            }
+
+            if (ctrl.shutdown_requested || ctrl.cancellation_requested) {
+                ctrl.waiting_for_answer = false;
+                ctrl.answer_submitted = false;
+                ctrl.waiting_prompt_id = 0;
+                secure_wipe(ctrl.secure->pending_response, SECURE_BUFFER_SIZE);
+                pthread_mutex_unlock(&ctrl.mutex);
+                free_replies(reply, num_msg);
+                return PAM_CONV_ERR;
+            }
+
+            int result = copy_secure_value_to_response(&reply[i].resp,
+                                                       ctrl.secure->pending_response);
+            secure_wipe(ctrl.secure->pending_response, SECURE_BUFFER_SIZE);
+            ctrl.waiting_for_answer = false;
+            ctrl.answer_submitted = false;
+            ctrl.waiting_prompt_id = 0;
+            reply[i].resp_retcode = 0;
+            if (result != PAM_SUCCESS) {
+                pthread_mutex_unlock(&ctrl.mutex);
+                free_replies(reply, num_msg);
+                return result;
+            }
+        } else if (style == PAM_TEXT_INFO || style == PAM_ERROR_MSG) {
+            pam_event_t event = {
+                .type = PAM_EVENT_AUTH_STATUS,
+                .transaction_id = ctrl.active_transaction_id,
+                .prompt_id = 0,
+                .echo_on = 0,
+                .is_error = style == PAM_ERROR_MSG,
+            };
+            event_set_text(&event, msg[i]->msg);
+            post_event_locked(event);
+        } else {
+            pthread_mutex_unlock(&ctrl.mutex);
+            free_replies(reply, num_msg);
+            return PAM_CONV_ERR;
         }
         /* INFO and ERROR: reply[i] stays zeroed (resp=NULL, retcode=0). */
     }
@@ -220,6 +311,11 @@ static void *worker_main(void *arg) {
 
         ctrl.auth_requested = false;
         ctrl.auth_in_progress = true;
+        ctrl.cancellation_requested = false;
+        ctrl.waiting_for_answer = false;
+        ctrl.answer_submitted = false;
+        ctrl.waiting_prompt_id = 0;
+        ctrl.prompts_seen = 0;
         uint64_t txn = ctrl.active_transaction_id;
         pthread_mutex_unlock(&ctrl.mutex);
 
@@ -228,8 +324,20 @@ static void *worker_main(void *arg) {
 
         pthread_mutex_lock(&ctrl.mutex);
         secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
+        secure_wipe(ctrl.secure->pending_response, SECURE_BUFFER_SIZE);
         ctrl.auth_in_progress = false;
-        if (ret == PAM_SUCCESS) {
+        ctrl.waiting_for_answer = false;
+        ctrl.answer_submitted = false;
+        ctrl.waiting_prompt_id = 0;
+        if (ctrl.cancellation_requested) {
+            ctrl.cancellation_requested = false;
+            post_event_locked((pam_event_t){
+                .type = PAM_EVENT_AUTH_CANCELLED,
+                .transaction_id = txn,
+                .prompt_id = 0,
+                .echo_on = 0,
+            });
+        } else if (ret == PAM_SUCCESS) {
             /* Refresh credentials (Kerberos tickets, etc.).
              * Do not downgrade a successful authentication if
              * credential refresh fails. */
@@ -238,12 +346,14 @@ static void *worker_main(void *arg) {
                 .type = PAM_EVENT_AUTH_SUCCESS,
                 .transaction_id = txn,
                 .prompt_id = 0,
+                .echo_on = 0,
             });
         } else {
             post_event_locked((pam_event_t){
                 .type = PAM_EVENT_AUTH_FAILURE,
                 .transaction_id = txn,
                 .prompt_id = 0,
+                .echo_on = 0,
             });
         }
     }
@@ -332,9 +442,8 @@ uint64_t pam_controller_start_auth(const char *password) {
 
     pthread_mutex_lock(&ctrl.mutex);
     if (ctrl.auth_requested || ctrl.auth_in_progress || ctrl.shutdown_requested) {
-        uint64_t txn = ctrl.active_transaction_id;
         pthread_mutex_unlock(&ctrl.mutex);
-        return txn;
+        return 0;
     }
 
     /* Stage the password in mlocked storage. */
@@ -348,11 +457,63 @@ uint64_t pam_controller_start_auth(const char *password) {
     uint64_t txn = ctrl.next_transaction_id++;
     ctrl.active_transaction_id = txn;
     ctrl.auth_requested = true;
+    ctrl.cancellation_requested = false;
+    ctrl.waiting_for_answer = false;
+    ctrl.answer_submitted = false;
+    ctrl.waiting_prompt_id = 0;
+    ctrl.prompts_seen = 0;
 
     pthread_cond_signal(&ctrl.cond);
     pthread_mutex_unlock(&ctrl.mutex);
 
     return txn;
+}
+
+int pam_controller_submit_answer(uint64_t transaction_id,
+                                 uint64_t prompt_id,
+                                 const char *answer) {
+    if (!ctrl.initialised) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&ctrl.mutex);
+    if (ctrl.shutdown_requested ||
+        ctrl.cancellation_requested ||
+        !ctrl.waiting_for_answer ||
+        ctrl.active_transaction_id != transaction_id ||
+        ctrl.waiting_prompt_id != prompt_id) {
+        pthread_mutex_unlock(&ctrl.mutex);
+        return 0;
+    }
+
+    size_t len = strlen(answer);
+    if (len >= SECURE_BUFFER_SIZE) {
+        len = SECURE_BUFFER_SIZE - 1;
+    }
+    memcpy(ctrl.secure->pending_response, answer, len);
+    ctrl.secure->pending_response[len] = '\0';
+    ctrl.answer_submitted = true;
+
+    pthread_cond_signal(&ctrl.cond);
+    pthread_mutex_unlock(&ctrl.mutex);
+    return 1;
+}
+
+void pam_controller_cancel_auth(uint64_t transaction_id) {
+    if (!ctrl.initialised || transaction_id == 0) {
+        return;
+    }
+
+    pthread_mutex_lock(&ctrl.mutex);
+    if (ctrl.active_transaction_id == transaction_id &&
+        (ctrl.auth_requested || ctrl.auth_in_progress)) {
+        ctrl.cancellation_requested = true;
+        ctrl.auth_requested = false;
+        secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
+        secure_wipe(ctrl.secure->pending_response, SECURE_BUFFER_SIZE);
+        pthread_cond_signal(&ctrl.cond);
+    }
+    pthread_mutex_unlock(&ctrl.mutex);
 }
 
 int pam_controller_get_fd(void) {

--- a/pam_controller.c
+++ b/pam_controller.c
@@ -79,6 +79,7 @@ static struct {
     bool cancellation_requested;
     bool waiting_for_answer;
     bool answer_submitted;
+    bool fatal_error;
 
     /* Transaction tracking. */
     uint64_t next_transaction_id;
@@ -89,6 +90,7 @@ static struct {
 
     /* PAM handle: exclusively owned by the worker. */
     pam_handle_t *pam_handle;
+    struct pam_conv pam_conv;
 
     /* Initialisation parameters (copied). */
     char *username;
@@ -145,6 +147,40 @@ static void event_set_text(pam_event_t *event, const char *text) {
         return;
     }
     snprintf(event->text, sizeof(event->text), "%s", text);
+}
+
+static int worker_conv_callback(int num_msg,
+                                const struct pam_message **msg,
+                                struct pam_response **resp,
+                                void *appdata_ptr);
+
+static int start_pam_handle(void) {
+    ctrl.pam_conv = (struct pam_conv){worker_conv_callback, NULL};
+    int ret = pam_start("i3lock", ctrl.username, &ctrl.pam_conv, &ctrl.pam_handle);
+    if (ret != PAM_SUCCESS) {
+        fprintf(stderr, "[i3lock] PAM worker: pam_start failed (%d)\n", ret);
+        ctrl.pam_handle = NULL;
+        return ret;
+    }
+
+    if (ctrl.display != NULL) {
+        ret = pam_set_item(ctrl.pam_handle, PAM_TTY, ctrl.display);
+        if (ret != PAM_SUCCESS) {
+            fprintf(stderr, "[i3lock] PAM worker: pam_set_item(PAM_TTY) failed (%d)\n", ret);
+            pam_end(ctrl.pam_handle, ret);
+            ctrl.pam_handle = NULL;
+            return ret;
+        }
+    }
+
+    return PAM_SUCCESS;
+}
+
+static void end_pam_handle(int status) {
+    if (ctrl.pam_handle != NULL) {
+        pam_end(ctrl.pam_handle, status);
+        ctrl.pam_handle = NULL;
+    }
 }
 
 /* pam_conv callback, running in the worker thread */
@@ -263,10 +299,8 @@ static void *worker_main(void *arg) {
     (void)arg;
 
     /* Initialise the PAM handle. The worker owns it exclusively. */
-    struct pam_conv conv = {worker_conv_callback, NULL};
-    int ret = pam_start("i3lock", ctrl.username, &conv, &ctrl.pam_handle);
+    int ret = start_pam_handle();
     if (ret != PAM_SUCCESS) {
-        fprintf(stderr, "[i3lock] PAM worker: pam_start failed (%d)\n", ret);
         pthread_mutex_lock(&ctrl.mutex);
         post_event_locked((pam_event_t){
             .type = PAM_EVENT_AUTH_FATAL,
@@ -275,23 +309,6 @@ static void *worker_main(void *arg) {
         });
         pthread_mutex_unlock(&ctrl.mutex);
         return NULL;
-    }
-
-    if (ctrl.display != NULL) {
-        ret = pam_set_item(ctrl.pam_handle, PAM_TTY, ctrl.display);
-        if (ret != PAM_SUCCESS) {
-            fprintf(stderr, "[i3lock] PAM worker: pam_set_item(PAM_TTY) failed (%d)\n", ret);
-            pthread_mutex_lock(&ctrl.mutex);
-            post_event_locked((pam_event_t){
-                .type = PAM_EVENT_AUTH_FATAL,
-                .transaction_id = 0,
-                .prompt_id = 0,
-            });
-            pthread_mutex_unlock(&ctrl.mutex);
-            pam_end(ctrl.pam_handle, ret);
-            ctrl.pam_handle = NULL;
-            return NULL;
-        }
     }
 
     pthread_mutex_lock(&ctrl.mutex);
@@ -348,6 +365,54 @@ static void *worker_main(void *arg) {
                 .prompt_id = 0,
                 .echo_on = 0,
             });
+        } else if (ret == PAM_ABORT) {
+            pam_event_t event = {
+                .type = PAM_EVENT_AUTH_FATAL,
+                .transaction_id = txn,
+                .prompt_id = 0,
+                .echo_on = 0,
+                .is_error = 1,
+            };
+            event_set_text(&event, "Authentication service failed");
+            ctrl.fatal_error = true;
+            post_event_locked(event);
+            pthread_mutex_unlock(&ctrl.mutex);
+            end_pam_handle(ret);
+            pthread_mutex_lock(&ctrl.mutex);
+        } else if (ret == PAM_SYSTEM_ERR || ret == PAM_SERVICE_ERR) {
+            pam_event_t event = {
+                .type = PAM_EVENT_AUTH_FAILURE,
+                .transaction_id = txn,
+                .prompt_id = 0,
+                .echo_on = 0,
+                .is_error = 1,
+            };
+            event_set_text(&event, "Authentication service error");
+            post_event_locked(event);
+
+            pthread_mutex_unlock(&ctrl.mutex);
+            end_pam_handle(ret);
+            ret = start_pam_handle();
+            pthread_mutex_lock(&ctrl.mutex);
+            if (ret == PAM_SUCCESS) {
+                post_event_locked((pam_event_t){
+                    .type = PAM_EVENT_AUTH_READY,
+                    .transaction_id = 0,
+                    .prompt_id = 0,
+                    .echo_on = 0,
+                });
+            } else {
+                pam_event_t fatal = {
+                    .type = PAM_EVENT_AUTH_FATAL,
+                    .transaction_id = 0,
+                    .prompt_id = 0,
+                    .echo_on = 0,
+                    .is_error = 1,
+                };
+                event_set_text(&fatal, "Authentication service failed");
+                ctrl.fatal_error = true;
+                post_event_locked(fatal);
+            }
         } else {
             post_event_locked((pam_event_t){
                 .type = PAM_EVENT_AUTH_FAILURE,
@@ -359,10 +424,7 @@ static void *worker_main(void *arg) {
     }
     pthread_mutex_unlock(&ctrl.mutex);
 
-    if (ctrl.pam_handle != NULL) {
-        pam_end(ctrl.pam_handle, PAM_SUCCESS);
-        ctrl.pam_handle = NULL;
-    }
+    end_pam_handle(PAM_SUCCESS);
     return NULL;
 }
 
@@ -441,7 +503,10 @@ uint64_t pam_controller_start_auth(const char *password) {
     }
 
     pthread_mutex_lock(&ctrl.mutex);
-    if (ctrl.auth_requested || ctrl.auth_in_progress || ctrl.shutdown_requested) {
+    if (ctrl.auth_requested ||
+        ctrl.auth_in_progress ||
+        ctrl.shutdown_requested ||
+        ctrl.fatal_error) {
         pthread_mutex_unlock(&ctrl.mutex);
         return 0;
     }

--- a/pam_controller.c
+++ b/pam_controller.c
@@ -1,0 +1,421 @@
+/*
+ * Fork-safe PAM controller for i3lock.
+ *
+ * The controller owns a dedicated worker thread that holds the PAM
+ * handle and runs pam_authenticate, pam_setcred, and pam_end. The
+ * main thread communicates with the worker through a mutex-protected
+ * command slot and receives results through an event queue drained via
+ * a libev-watched pipe.
+ *
+ * Credential copies owned by the controller live in a single mlock()ed
+ * region. The foundation preserves legacy i3lock conversation semantics
+ * during one PAM transaction and wipes the staged input when
+ * pam_authenticate returns or the controller shuts down.
+ */
+
+#include <config.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <security/pam_appl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#ifdef HAVE_EXPLICIT_BZERO
+#include <strings.h>
+#endif
+
+#include "i3lock.h"
+#include "pam_controller.h"
+
+#define MAX_EVENTS 16
+#define SECURE_BUFFER_SIZE 512
+
+/* secure wiping */
+
+static void secure_wipe(void *buf, size_t len) {
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(buf, len);
+#else
+    volatile char *p = buf;
+    for (size_t i = 0; i < len; i++) {
+        p[i] = 0;
+    }
+#endif
+}
+
+/* secure storage (mlocked) */
+
+struct secure_storage {
+    char deferred_input[SECURE_BUFFER_SIZE];
+    /* Reserved for the sequential prompt state machine. */
+    char pending_response[SECURE_BUFFER_SIZE];
+};
+
+/* controller state */
+
+static struct {
+    /* Thread synchronisation. */
+    pthread_t worker;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+
+    /* Event queue: worker to main thread. */
+    pam_event_t events[MAX_EVENTS];
+    int event_count;
+
+    /* Wake-up pipe: worker writes [1], main reads [0]. */
+    int pipe_fds[2];
+
+    /* Worker command slot: main to worker. */
+    bool auth_requested;
+    bool auth_in_progress;
+    bool shutdown_requested;
+
+    /* Transaction tracking. */
+    uint64_t next_transaction_id;
+    uint64_t next_prompt_id;
+    uint64_t active_transaction_id;
+
+    /* PAM handle: exclusively owned by the worker. */
+    pam_handle_t *pam_handle;
+
+    /* Initialisation parameters (copied). */
+    char *username;
+    char *display;
+
+    /* Credential storage: mlocked. */
+    struct secure_storage *secure;
+
+    bool initialised;
+} ctrl;
+
+/* internal helpers */
+
+/* Post an event and wake the main event loop. Must be called with
+ * ctrl.mutex held. */
+static void post_event_locked(pam_event_t event) {
+    if (ctrl.event_count < MAX_EVENTS) {
+        ctrl.events[ctrl.event_count++] = event;
+    } else {
+        ctrl.events[MAX_EVENTS - 1] = (pam_event_t){
+            .type = PAM_EVENT_AUTH_FATAL,
+            .transaction_id = event.transaction_id,
+            .prompt_id = event.prompt_id,
+        };
+    }
+    char byte = 0;
+    (void)write(ctrl.pipe_fds[1], &byte, 1);
+}
+
+/* pam_conv callback, running in the worker thread */
+
+/*
+ * Foundation-stage behaviour: every prompt in this callback batch
+ * receives the deferred input that was staged by the main thread before
+ * authentication started. INFO and ERROR messages receive a NULL
+ * response.
+ *
+ * Note: uses (*resp)[i] (correct array indexing), not the resp[i]
+ * pattern in the original conv_callback, which is a wild pointer
+ * dereference when i is greater than zero.
+ */
+static int worker_conv_callback(int num_msg,
+                                const struct pam_message **msg,
+                                struct pam_response **resp,
+                                void *appdata_ptr) {
+    (void)appdata_ptr;
+
+    if (num_msg <= 0) {
+        return PAM_CONV_ERR;
+    }
+
+    struct pam_response *reply = calloc((size_t)num_msg, sizeof(*reply));
+    if (reply == NULL) {
+        return PAM_BUF_ERR;
+    }
+
+    pthread_mutex_lock(&ctrl.mutex);
+    for (int i = 0; i < num_msg; i++) {
+        int style = msg[i]->msg_style;
+        if (style == PAM_PROMPT_ECHO_OFF || style == PAM_PROMPT_ECHO_ON) {
+            reply[i].resp = strdup(ctrl.secure->deferred_input);
+            reply[i].resp_retcode = 0;
+            if (reply[i].resp == NULL) {
+                pthread_mutex_unlock(&ctrl.mutex);
+                for (int j = 0; j < i; j++) {
+                    if (reply[j].resp != NULL) {
+                        secure_wipe(reply[j].resp, strlen(reply[j].resp));
+                        free(reply[j].resp);
+                    }
+                }
+                free(reply);
+                return PAM_BUF_ERR;
+            }
+        }
+        /* INFO and ERROR: reply[i] stays zeroed (resp=NULL, retcode=0). */
+    }
+    pthread_mutex_unlock(&ctrl.mutex);
+
+    *resp = reply;
+    return PAM_SUCCESS;
+}
+
+/* worker thread */
+
+static void *worker_main(void *arg) {
+    (void)arg;
+
+    /* Initialise the PAM handle. The worker owns it exclusively. */
+    struct pam_conv conv = {worker_conv_callback, NULL};
+    int ret = pam_start("i3lock", ctrl.username, &conv, &ctrl.pam_handle);
+    if (ret != PAM_SUCCESS) {
+        fprintf(stderr, "[i3lock] PAM worker: pam_start failed (%d)\n", ret);
+        pthread_mutex_lock(&ctrl.mutex);
+        post_event_locked((pam_event_t){
+            .type = PAM_EVENT_AUTH_FATAL,
+            .transaction_id = 0,
+            .prompt_id = 0,
+        });
+        pthread_mutex_unlock(&ctrl.mutex);
+        return NULL;
+    }
+
+    if (ctrl.display != NULL) {
+        ret = pam_set_item(ctrl.pam_handle, PAM_TTY, ctrl.display);
+        if (ret != PAM_SUCCESS) {
+            fprintf(stderr, "[i3lock] PAM worker: pam_set_item(PAM_TTY) failed (%d)\n", ret);
+            pthread_mutex_lock(&ctrl.mutex);
+            post_event_locked((pam_event_t){
+                .type = PAM_EVENT_AUTH_FATAL,
+                .transaction_id = 0,
+                .prompt_id = 0,
+            });
+            pthread_mutex_unlock(&ctrl.mutex);
+            pam_end(ctrl.pam_handle, ret);
+            ctrl.pam_handle = NULL;
+            return NULL;
+        }
+    }
+
+    pthread_mutex_lock(&ctrl.mutex);
+    post_event_locked((pam_event_t){
+        .type = PAM_EVENT_AUTH_READY,
+        .transaction_id = 0,
+        .prompt_id = 0,
+    });
+    while (!ctrl.shutdown_requested) {
+        /* Wait for an authentication request or shutdown. */
+        while (!ctrl.auth_requested && !ctrl.shutdown_requested) {
+            pthread_cond_wait(&ctrl.cond, &ctrl.mutex);
+        }
+        if (ctrl.shutdown_requested) {
+            break;
+        }
+
+        ctrl.auth_requested = false;
+        ctrl.auth_in_progress = true;
+        uint64_t txn = ctrl.active_transaction_id;
+        pthread_mutex_unlock(&ctrl.mutex);
+
+        /* pam_authenticate blocks and invokes worker_conv_callback. */
+        ret = pam_authenticate(ctrl.pam_handle, 0);
+
+        pthread_mutex_lock(&ctrl.mutex);
+        secure_wipe(ctrl.secure->deferred_input, SECURE_BUFFER_SIZE);
+        ctrl.auth_in_progress = false;
+        if (ret == PAM_SUCCESS) {
+            /* Refresh credentials (Kerberos tickets, etc.).
+             * Do not downgrade a successful authentication if
+             * credential refresh fails. */
+            pam_setcred(ctrl.pam_handle, PAM_REFRESH_CRED);
+            post_event_locked((pam_event_t){
+                .type = PAM_EVENT_AUTH_SUCCESS,
+                .transaction_id = txn,
+                .prompt_id = 0,
+            });
+        } else {
+            post_event_locked((pam_event_t){
+                .type = PAM_EVENT_AUTH_FAILURE,
+                .transaction_id = txn,
+                .prompt_id = 0,
+            });
+        }
+    }
+    pthread_mutex_unlock(&ctrl.mutex);
+
+    if (ctrl.pam_handle != NULL) {
+        pam_end(ctrl.pam_handle, PAM_SUCCESS);
+        ctrl.pam_handle = NULL;
+    }
+    return NULL;
+}
+
+/* public API */
+
+void pam_controller_init(const char *username, const char *display) {
+    if (ctrl.initialised) {
+        return;
+    }
+
+    /* Copy configuration strings. */
+    ctrl.username = strdup(username);
+    if (ctrl.username == NULL) {
+        perror("strdup");
+        exit(EXIT_FAILURE);
+    }
+    if (display != NULL) {
+        ctrl.display = strdup(display);
+        if (ctrl.display == NULL) {
+            perror("strdup");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    /* Allocate and mlock secure storage. */
+    ctrl.secure = calloc(1, sizeof(*ctrl.secure));
+    if (ctrl.secure == NULL) {
+        perror("calloc");
+        exit(EXIT_FAILURE);
+    }
+#if defined(__linux__)
+    if (mlock(ctrl.secure, sizeof(*ctrl.secure)) != 0) {
+        perror("mlock(secure storage)");
+        exit(EXIT_FAILURE);
+    }
+#endif
+
+    /* Create the wake-up pipe. The read end is non-blocking so that
+     * drain_events never stalls the event loop. */
+    if (pipe(ctrl.pipe_fds) != 0) {
+        perror("pipe");
+        exit(EXIT_FAILURE);
+    }
+    int flags = fcntl(ctrl.pipe_fds[0], F_GETFL);
+    if (flags == -1 || fcntl(ctrl.pipe_fds[0], F_SETFL, flags | O_NONBLOCK) == -1) {
+        perror("fcntl(O_NONBLOCK)");
+        exit(EXIT_FAILURE);
+    }
+    flags = fcntl(ctrl.pipe_fds[1], F_GETFL);
+    if (flags == -1 || fcntl(ctrl.pipe_fds[1], F_SETFL, flags | O_NONBLOCK) == -1) {
+        perror("fcntl(O_NONBLOCK)");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Initialise synchronisation primitives. */
+    if (pthread_mutex_init(&ctrl.mutex, NULL) != 0 ||
+        pthread_cond_init(&ctrl.cond, NULL) != 0) {
+        fprintf(stderr, "[i3lock] could not initialise mutex/condvar\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctrl.next_transaction_id = 1;
+    ctrl.next_prompt_id = 1;
+    ctrl.initialised = true;
+
+    /* Start the worker thread. */
+    if (pthread_create(&ctrl.worker, NULL, worker_main, NULL) != 0) {
+        perror("pthread_create");
+        exit(EXIT_FAILURE);
+    }
+}
+
+uint64_t pam_controller_start_auth(const char *password) {
+    if (!ctrl.initialised) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&ctrl.mutex);
+    if (ctrl.auth_requested || ctrl.auth_in_progress || ctrl.shutdown_requested) {
+        uint64_t txn = ctrl.active_transaction_id;
+        pthread_mutex_unlock(&ctrl.mutex);
+        return txn;
+    }
+
+    /* Stage the password in mlocked storage. */
+    size_t len = strlen(password);
+    if (len >= SECURE_BUFFER_SIZE) {
+        len = SECURE_BUFFER_SIZE - 1;
+    }
+    memcpy(ctrl.secure->deferred_input, password, len);
+    ctrl.secure->deferred_input[len] = '\0';
+
+    uint64_t txn = ctrl.next_transaction_id++;
+    ctrl.active_transaction_id = txn;
+    ctrl.auth_requested = true;
+
+    pthread_cond_signal(&ctrl.cond);
+    pthread_mutex_unlock(&ctrl.mutex);
+
+    return txn;
+}
+
+int pam_controller_get_fd(void) {
+    if (!ctrl.initialised) {
+        return -1;
+    }
+    return ctrl.pipe_fds[0];
+}
+
+int pam_controller_drain_events(void (*callback)(const pam_event_t *event)) {
+    /* Drain the pipe so that libev stops signalling readability. */
+    char buf[64];
+    ssize_t nread;
+    do {
+        nread = read(ctrl.pipe_fds[0], buf, sizeof(buf));
+    } while (nread > 0 || (nread == -1 && errno == EINTR));
+
+    pthread_mutex_lock(&ctrl.mutex);
+    int count = ctrl.event_count;
+    pam_event_t snapshot[MAX_EVENTS];
+    if (count > 0) {
+        memcpy(snapshot, ctrl.events, (size_t)count * sizeof(pam_event_t));
+        ctrl.event_count = 0;
+    }
+    pthread_mutex_unlock(&ctrl.mutex);
+
+    for (int i = 0; i < count; i++) {
+        callback(&snapshot[i]);
+    }
+    return count;
+}
+
+void pam_controller_cleanup(void) {
+    if (!ctrl.initialised) {
+        return;
+    }
+
+    /* Tell the worker to exit and wait for it. */
+    pthread_mutex_lock(&ctrl.mutex);
+    ctrl.shutdown_requested = true;
+    pthread_cond_signal(&ctrl.cond);
+    pthread_mutex_unlock(&ctrl.mutex);
+
+    pthread_join(ctrl.worker, NULL);
+
+    /* Wipe and free secure storage. */
+    if (ctrl.secure != NULL) {
+        secure_wipe(ctrl.secure, sizeof(*ctrl.secure));
+#if defined(__linux__)
+        munlock(ctrl.secure, sizeof(*ctrl.secure));
+#endif
+        free(ctrl.secure);
+        ctrl.secure = NULL;
+    }
+
+    close(ctrl.pipe_fds[0]);
+    close(ctrl.pipe_fds[1]);
+    pthread_mutex_destroy(&ctrl.mutex);
+    pthread_cond_destroy(&ctrl.cond);
+    free(ctrl.username);
+    free(ctrl.display);
+    ctrl.username = NULL;
+    ctrl.display = NULL;
+
+    ctrl.initialised = false;
+}

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -49,6 +49,11 @@ extern bool unlock_indicator;
 
 /* List of pressed modifiers, or NULL if none are pressed. */
 extern char *modifier_string;
+extern char pam_status_text[I3LOCK_PAM_UI_TEXT_MAX];
+extern char pam_prompt_text[I3LOCK_PAM_UI_TEXT_MAX];
+extern char pam_visible_input[I3LOCK_PAM_VISIBLE_INPUT_MAX];
+extern bool pam_status_is_error;
+extern bool pam_prompt_echo_on;
 /* Name of the current keyboard layout or NULL if not initialized. */
 char *layout_string = NULL;
 
@@ -116,6 +121,19 @@ static void display_button_text(
     } else {
         cairo_set_source_rgb(ctx, 1., 1., 1.);
     }
+    cairo_show_text(ctx, text);
+    cairo_close_path(ctx);
+}
+
+static void display_centered_text(cairo_t *ctx, const char *text, double y_offset) {
+    cairo_text_extents_t extents;
+    double x, y;
+
+    cairo_text_extents(ctx, text, &extents);
+    x = BUTTON_CENTER - ((extents.width / 2) + extents.x_bearing);
+    y = BUTTON_CENTER - ((extents.height / 2) + extents.y_bearing) + y_offset;
+
+    cairo_move_to(ctx, x, y);
     cairo_show_text(ctx, text);
     cairo_close_path(ctx);
 }
@@ -292,6 +310,7 @@ void draw_image(xcb_pixmap_t bg_pixmap, uint32_t *resolution) {
 
         /* Display a (centered) text of the current PAM state. */
         char *text = NULL;
+        bool prompt_text_is_main = false;
         /* We don't want to show more than a 3-digit number. */
         char buf[4];
 
@@ -325,11 +344,41 @@ void draw_image(xcb_pixmap_t bg_pixmap, uint32_t *resolution) {
                     cairo_set_source_rgb(ctx, 1, 0, 0);
                     cairo_set_font_size(ctx, 32.0);
                 }
+                if (pam_prompt_echo_on && pam_visible_input[0] != '\0') {
+                    text = pam_visible_input;
+                    cairo_set_font_size(ctx, 16.0);
+                } else if (pam_prompt_text[0] != '\0' && !pam_prompt_echo_on) {
+                    text = pam_prompt_text;
+                    prompt_text_is_main = true;
+                    cairo_set_font_size(ctx, 16.0);
+                }
                 break;
         }
 
         if (text) {
             display_button_text(ctx, text, 0., use_dark_text);
+        }
+
+        if (pam_prompt_text[0] != '\0' && !prompt_text_is_main) {
+            cairo_set_font_size(ctx, 12.0);
+            if (use_dark_text) {
+                cairo_set_source_rgb(ctx, 0., 0., 0.);
+            } else {
+                cairo_set_source_rgb(ctx, 1., 1., 1.);
+            }
+            display_centered_text(ctx, pam_prompt_text, -28.);
+        }
+
+        if (pam_status_text[0] != '\0') {
+            cairo_set_font_size(ctx, 12.0);
+            if (pam_status_is_error) {
+                cairo_set_source_rgb(ctx, 1., 0., 0.);
+            } else if (use_dark_text) {
+                cairo_set_source_rgb(ctx, 0., 0., 0.);
+            } else {
+                cairo_set_source_rgb(ctx, 1., 1., 1.);
+            }
+            display_centered_text(ctx, pam_status_text, 28.);
         }
 
         if (modifier_string != NULL) {


### PR DESCRIPTION
## Summary

  This PR reworks Linux PAM authentication so i3lock can handle sequential PAM conversations properly, including providers
  that issue multiple prompts within one `pam_authenticate()` call.

  Main changes:

  - Move PAM authentication into a fork-safe worker controller started after i3lock’s final daemonizing fork.
  - Add transaction and prompt IDs so stale PAM events cannot affect a newer authentication attempt.
  - Support ordered PAM batches containing:
    - `PAM_TEXT_INFO`
    - `PAM_ERROR_MSG`
    - `PAM_PROMPT_ECHO_OFF`
    - `PAM_PROMPT_ECHO_ON`
  - Wait for fresh user input for later PAM prompts instead of replaying the first submitted password/PIN.
  - Render PAM prompt/status text in the lock indicator.
  - Support visible input for `PAM_PROMPT_ECHO_ON`.
  - Keep `pam_setcred()` and `pam_end()` worker-owned.
  - Treat `PAM_ABORT` and `PAM_MAXTRIES` as fatal/non-retriable.
  - Recreate the PAM handle after cancellation and retryable service/system errors.
  - Harden post-lock failure paths so controller/resource failures fail closed instead of exiting i3lock.
  - Harden synthetic `MapNotify`, sleep-lock FD handling, SIGPIPE, event queue overflow, and malformed PAM conversation
  inputs.

  ## Motivation

  Some PAM providers, such as Himmelblau/Entra, use multi-step conversations: informational messages, retry prompts, password
  fallback, and possible MFA-related prompts. The previous i3lock PAM path effectively assumed a single password response and
  could replay the same input across multiple prompts.

  This PR makes i3lock follow the PAM conversation model more closely while preserving the ordinary single-password UX.

  ## Validation

  Built locally:

  ```sh
  meson compile -C build
  git diff --check

  Also validated against the external PAM/Xvfb harness, including regressions for:

  - Himmelblau-style wrong PIN followed by fresh correct PIN
  - mixed PAM batches
  - visible prompts
  - Escape cancellation
  - late PAM success after cancellation
  - PAM handle recreation
  - PAM_ABORT
  - PAM_MAXTRIES
  - status-message flood handling
